### PR TITLE
Add in-chat AI model selection dialog

### DIFF
--- a/scripts/mcp-test.html
+++ b/scripts/mcp-test.html
@@ -73,6 +73,7 @@
     <script type="module">
         import { McpClient } from '/src/lib/mcp/client.ts';
         import { getGeminiResponse } from '/src/services/openRouter.ts';
+        import { DEFAULT_MODEL_ID } from '/src/hooks/modelSelectionProviderContext.ts';
 
         const OUTPUT = document.getElementById('output');
         const logLine = (message, data, level = 'info') => {
@@ -126,6 +127,7 @@
                 const firstResponse = await getGeminiResponse(messagesPhaseOne, {
                     onStream: (update) => logLine('Phase 1 stream update', update, 'notice'),
                     tools: toolDefinitions,
+                    model: DEFAULT_MODEL_ID,
                 });
                 firstResponseRaw = firstResponse.raw;
                 logLine('Phase 1 raw Gemini response', firstResponseRaw);
@@ -223,6 +225,7 @@
                 const secondResponse = await getGeminiResponse(messagesPhaseTwo, {
                     onStream: (update) => logLine('Phase 2 stream update', update, 'notice'),
                     tools: toolDefinitions,
+                    model: DEFAULT_MODEL_ID,
                 });
                 logLine('Phase 2 raw Gemini response', secondResponse.raw);
                 logLine('Phase 2 aggregated text response', secondResponse.content, 'success');

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -5,22 +5,25 @@ import ChatPane from './ChatPane';
 import { ChatProvider } from '@/hooks/chatProvider';
 import { SystemInstructionsProvider } from '@/hooks/systemInstructionProvider';
 import { McpProvider } from '@/hooks/mcpProvider';
+import { ModelSelectionProvider } from '@/hooks/modelSelectionProvider';
 
 const ChatLayout = () => {
     return (
         <McpProvider>
             <SystemInstructionsProvider>
-                <ChatProvider>
-                    <ResizablePanelGroup direction="horizontal" className="h-full w-full">
-                        <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
-                            <ChatSidebar />
-                        </ResizablePanel>
-                        <ResizableHandle withHandle />
-                        <ResizablePanel>
-                            <ChatPane />
-                        </ResizablePanel>
-                    </ResizablePanelGroup>
-                </ChatProvider>
+                <ModelSelectionProvider>
+                    <ChatProvider>
+                        <ResizablePanelGroup direction="horizontal" className="h-full w-full">
+                            <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
+                                <ChatSidebar />
+                            </ResizablePanel>
+                            <ResizableHandle withHandle />
+                            <ResizablePanel>
+                                <ChatPane />
+                            </ResizablePanel>
+                        </ResizablePanelGroup>
+                    </ChatProvider>
+                </ModelSelectionProvider>
             </SystemInstructionsProvider>
         </McpProvider>
     );

--- a/src/components/chat/ModelSelectionDialog.tsx
+++ b/src/components/chat/ModelSelectionDialog.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    CommandDialog,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command';
+import { useModelSelection } from '@/hooks/useModelSelection';
+import { fetchOpenRouterModels, type OpenRouterModel } from '@/services/openRouter';
+import { PRESEEDED_MODEL_USAGE } from '@/hooks/modelSelectionProviderContext';
+import { Check, Loader2 } from 'lucide-react';
+
+interface ModelSelectionDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+interface ModelWithUsage extends OpenRouterModel {
+    usageScore: number;
+}
+
+export const ModelSelectionDialog: React.FC<ModelSelectionDialogProps> = ({ open, onOpenChange }) => {
+    const { selectedModel, selectModel, getUsageScore } = useModelSelection();
+    const [models, setModels] = useState<OpenRouterModel[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState('');
+
+    useEffect(() => {
+        if (!open) {
+            setSearchTerm('');
+            return;
+        }
+
+        const controller = new AbortController();
+        let isCancelled = false;
+
+        const loadModels = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const result = await fetchOpenRouterModels({ signal: controller.signal });
+                if (isCancelled) return;
+                setModels(result);
+            } catch (err) {
+                if (isCancelled) return;
+                const message = err instanceof Error ? err.message : 'Failed to load models';
+                setError(message);
+                setModels([]);
+            } finally {
+                if (!isCancelled) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        loadModels();
+
+        return () => {
+            isCancelled = true;
+            controller.abort();
+        };
+    }, [open]);
+
+    const combinedModels = useMemo(() => {
+        const modelMap = new Map<string, OpenRouterModel>();
+        for (const model of models) {
+            modelMap.set(model.id, model);
+        }
+        for (const modelId of Object.keys(PRESEEDED_MODEL_USAGE)) {
+            if (!modelMap.has(modelId)) {
+                modelMap.set(modelId, { id: modelId, name: modelId } as OpenRouterModel);
+            }
+        }
+        return Array.from(modelMap.values());
+    }, [models]);
+
+    const modelsWithUsage = useMemo<ModelWithUsage[]>(() => {
+        return combinedModels
+            .map((model) => ({
+                ...model,
+                usageScore: getUsageScore(model.id),
+            }))
+            .sort((a, b) => {
+                if (b.usageScore !== a.usageScore) {
+                    return b.usageScore - a.usageScore;
+                }
+                return a.id.localeCompare(b.id);
+            });
+    }, [combinedModels, getUsageScore]);
+
+    const filteredModels = useMemo(() => {
+        const term = searchTerm.trim().toLowerCase();
+        if (!term) {
+            return modelsWithUsage;
+        }
+        return modelsWithUsage.filter((model) => {
+            const label = (model.name ?? model.id).toLowerCase();
+            return label.includes(term);
+        });
+    }, [modelsWithUsage, searchTerm]);
+
+    const handleSelect = (model: ModelWithUsage) => {
+        selectModel(model.id, { label: model.name ?? model.id });
+        onOpenChange(false);
+    };
+
+    return (
+        <CommandDialog open={open} onOpenChange={onOpenChange}>
+            <CommandInput
+                placeholder="Search models..."
+                value={searchTerm}
+                onValueChange={setSearchTerm}
+                autoFocus
+            />
+            <CommandList>
+                {loading ? (
+                    <div className="flex items-center justify-center px-4 py-6 text-sm text-muted-foreground">
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Loading models...
+                    </div>
+                ) : error ? (
+                    <div className="px-4 py-6 text-sm text-destructive">{error}</div>
+                ) : filteredModels.length === 0 ? (
+                    <div className="px-4 py-6 text-sm text-muted-foreground">
+                        No models match your search.
+                    </div>
+                ) : (
+                    <CommandGroup heading="Available Models">
+                        {filteredModels.map((model) => {
+                            const displayName = model.name ?? model.id;
+                            return (
+                                <CommandItem
+                                    key={model.id}
+                                    value={model.id}
+                                    onSelect={() => handleSelect(model)}
+                                    className="flex items-start gap-3"
+                                >
+                                    <div className="flex flex-1 flex-col gap-1">
+                                        <span className="text-sm font-medium text-foreground">{displayName}</span>
+                                        {model.description ? (
+                                            <span className="text-xs text-muted-foreground truncate">
+                                                {model.description}
+                                            </span>
+                                        ) : null}
+                                        {model.context_length ? (
+                                            <span className="text-[11px] text-muted-foreground">
+                                                Context window: {model.context_length.toLocaleString()} tokens
+                                            </span>
+                                        ) : null}
+                                    </div>
+                                    <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+                                        <span className="rounded-full bg-muted px-2 py-0.5 text-foreground">
+                                            {model.usageScore} uses
+                                        </span>
+                                        {selectedModel === model.id && (
+                                            <Check className="h-4 w-4 text-primary" />
+                                        )}
+                                    </div>
+                                </CommandItem>
+                            );
+                        })}
+                    </CommandGroup>
+                )}
+            </CommandList>
+        </CommandDialog>
+    );
+};
+
+export default ModelSelectionDialog;
+

--- a/src/hooks/modelSelectionProvider.tsx
+++ b/src/hooks/modelSelectionProvider.tsx
@@ -1,0 +1,131 @@
+import React, { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    DEFAULT_MODEL_ID,
+    MODEL_USAGE_WINDOW_MS,
+    ModelSelectionContext,
+    ModelUsageRecords,
+    PRESEEDED_MODEL_USAGE,
+    SelectedModelState,
+} from './modelSelectionProviderContext';
+
+const SELECTED_MODEL_STORAGE_KEY = 'life-currents:selected-model';
+const MODEL_USAGE_STORAGE_KEY = 'life-currents:model-usage-records';
+
+type StoredSelectedModel = SelectedModelState | string | null;
+
+type SerializableUsageRecords = Record<string, number[]>;
+
+const loadSelectedModel = (): SelectedModelState => {
+    if (typeof window === 'undefined') {
+        return { id: DEFAULT_MODEL_ID };
+    }
+
+    const raw = window.localStorage.getItem(SELECTED_MODEL_STORAGE_KEY);
+    if (!raw) {
+        return { id: DEFAULT_MODEL_ID };
+    }
+
+    try {
+        const parsed: StoredSelectedModel = JSON.parse(raw);
+        if (typeof parsed === 'string') {
+            return { id: parsed };
+        }
+        if (parsed && typeof parsed === 'object' && typeof parsed.id === 'string') {
+            return { id: parsed.id, label: typeof parsed.label === 'string' ? parsed.label : undefined };
+        }
+    } catch (error) {
+        console.warn('[ModelSelectionProvider] Failed to parse stored model preference', error);
+    }
+
+    return { id: DEFAULT_MODEL_ID };
+};
+
+const pruneUsageRecords = (records: SerializableUsageRecords): SerializableUsageRecords => {
+    const now = Date.now();
+    return Object.entries(records).reduce<SerializableUsageRecords>((acc, [modelId, timestamps]) => {
+        const pruned = timestamps.filter((timestamp) => now - timestamp <= MODEL_USAGE_WINDOW_MS);
+        if (pruned.length > 0) {
+            acc[modelId] = pruned;
+        }
+        return acc;
+    }, {});
+};
+
+const loadUsageRecords = (): SerializableUsageRecords => {
+    if (typeof window === 'undefined') {
+        return {};
+    }
+
+    const raw = window.localStorage.getItem(MODEL_USAGE_STORAGE_KEY);
+    if (!raw) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as SerializableUsageRecords;
+        if (!parsed || typeof parsed !== 'object') {
+            return {};
+        }
+        return pruneUsageRecords(parsed);
+    } catch (error) {
+        console.warn('[ModelSelectionProvider] Failed to parse stored usage records', error);
+        return {};
+    }
+};
+
+export const ModelSelectionProvider: React.FC<PropsWithChildren> = ({ children }) => {
+    const [selectedModelState, setSelectedModelState] = useState<SelectedModelState>(() => loadSelectedModel());
+    const [usageRecords, setUsageRecords] = useState<ModelUsageRecords>(() => loadUsageRecords());
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, JSON.stringify(selectedModelState));
+    }, [selectedModelState]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        window.localStorage.setItem(MODEL_USAGE_STORAGE_KEY, JSON.stringify(usageRecords));
+    }, [usageRecords]);
+
+    const selectModel = useCallback((modelId: string, options?: { label?: string }) => {
+        setSelectedModelState({ id: modelId, label: options?.label });
+    }, []);
+
+    const recordModelUsage = useCallback((modelId: string) => {
+        setUsageRecords((previous) => {
+            const now = Date.now();
+            const existing = previous[modelId] ?? [];
+            const pruned = existing.filter((timestamp) => now - timestamp <= MODEL_USAGE_WINDOW_MS);
+            return {
+                ...previous,
+                [modelId]: [...pruned, now],
+            };
+        });
+    }, []);
+
+    const getUsageScore = useCallback(
+        (modelId: string) => {
+            const now = Date.now();
+            const timestamps = usageRecords[modelId] ?? [];
+            const recentCount = timestamps.filter((timestamp) => now - timestamp <= MODEL_USAGE_WINDOW_MS).length;
+            const base = PRESEEDED_MODEL_USAGE[modelId] ?? 0;
+            return base + recentCount;
+        },
+        [usageRecords]
+    );
+
+    const contextValue = useMemo(
+        () => ({
+            selectedModel: selectedModelState.id,
+            selectedModelLabel: selectedModelState.label,
+            selectModel,
+            recordModelUsage,
+            getUsageScore,
+            usageRecords,
+        }),
+        [getUsageScore, recordModelUsage, selectModel, selectedModelState.id, selectedModelState.label, usageRecords]
+    );
+
+    return <ModelSelectionContext.Provider value={contextValue}>{children}</ModelSelectionContext.Provider>;
+};
+

--- a/src/hooks/modelSelectionProviderContext.ts
+++ b/src/hooks/modelSelectionProviderContext.ts
@@ -1,0 +1,36 @@
+import { createContext } from 'react';
+
+export const MODEL_USAGE_WINDOW_HOURS = 72;
+export const MODEL_USAGE_WINDOW_MS = MODEL_USAGE_WINDOW_HOURS * 60 * 60 * 1000;
+
+export const DEFAULT_MODEL_ID = 'google/gemini-2.5-pro';
+
+export const PRESEEDED_MODEL_USAGE: Record<string, number> = {
+    'openai/gpt-5': 10,
+    'google/gemini-2.5-pro': 10,
+    'anthropic/claude-sonnet-4.5': 10,
+    'anthropic/claude-sonnet-4': 10,
+    'anthropic/claude-opus-4.1': 10,
+    'x-ai/grok-4-fast': 10,
+};
+
+export interface ModelUsageRecords {
+    [modelId: string]: number[];
+}
+
+export interface SelectedModelState {
+    id: string;
+    label?: string;
+}
+
+export interface ModelSelectionContextValue {
+    selectedModel: string;
+    selectedModelLabel?: string;
+    selectModel: (modelId: string, options?: { label?: string }) => void;
+    recordModelUsage: (modelId: string) => void;
+    getUsageScore: (modelId: string) => number;
+    usageRecords: ModelUsageRecords;
+}
+
+export const ModelSelectionContext = createContext<ModelSelectionContextValue | undefined>(undefined);
+

--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ModelSelectionContext } from './modelSelectionProviderContext';
+
+export const useModelSelection = () => {
+    const context = useContext(ModelSelectionContext);
+    if (!context) {
+        throw new Error('useModelSelection must be used within a ModelSelectionProvider');
+    }
+    return context;
+};
+


### PR DESCRIPTION
## Summary
- add a model selection provider and dialog that fetches the latest OpenRouter models and sorts them by recent usage
- update the chat pane UI to surface the selected model, record usage, and pass the chosen model with high-effort reasoning on every request
- expose model-list fetching from the OpenRouter service and ensure ancillary scripts use the shared model constant

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc3628ff9083238e9091f79a9ff4c6