### PR TITLE
Add in-chat model selector with usage tracking

### DIFF
--- a/src/components/chat/ModelSelectionDialog.tsx
+++ b/src/components/chat/ModelSelectionDialog.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { fetchAvailableModels } from '@/services/openRouter';
+import type { ModelOption } from '@/types/models';
+import { getUsageCounts, PRESEEDED_MODELS } from '@/lib/modelUsage';
+import { cn } from '@/lib/utils';
+
+interface ModelSelectionDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    selectedModelId: string;
+    onSelect: (model: ModelOption) => void;
+    usageVersion: number;
+}
+
+interface ModelWithUsage extends ModelOption {
+    usage: number;
+}
+
+const ModelSelectionDialog: React.FC<ModelSelectionDialogProps> = ({
+    open,
+    onOpenChange,
+    selectedModelId,
+    onSelect,
+    usageVersion,
+}) => {
+    const [models, setModels] = useState<ModelOption[]>([]);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [usageCounts, setUsageCounts] = useState<Record<string, number>>({});
+
+    useEffect(() => {
+        if (!open) return;
+        let isActive = true;
+        setLoading(true);
+        setError(null);
+        setSearchQuery('');
+
+        fetchAvailableModels()
+            .then((fetched) => {
+                if (!isActive) return;
+                const withFallbacks = [...fetched];
+                Object.entries(PRESEEDED_MODELS).forEach(([modelId, label]) => {
+                    if (!withFallbacks.some((model) => model.id === modelId)) {
+                        withFallbacks.push({ id: modelId, name: label });
+                    }
+                });
+                setModels(withFallbacks);
+            })
+            .catch((err) => {
+                if (!isActive) return;
+                console.error('Failed to fetch OpenRouter models:', err);
+                setError(err instanceof Error ? err.message : 'Failed to load models.');
+                const fallbackList = Object.entries(PRESEEDED_MODELS).map(([id, name]) => ({ id, name }));
+                setModels(fallbackList);
+            })
+            .finally(() => {
+                if (isActive) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            isActive = false;
+        };
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        try {
+            setUsageCounts(getUsageCounts());
+        } catch (err) {
+            console.warn('Failed to compute model usage counts:', err);
+            setUsageCounts({});
+        }
+    }, [open, usageVersion]);
+
+    const filteredModels = useMemo<ModelWithUsage[]>(() => {
+        const usageSnapshot = usageCounts;
+        const query = searchQuery.trim().toLowerCase();
+
+        const augmented = models.map((model) => ({
+            ...model,
+            usage: usageSnapshot[model.id] ?? 0,
+        }));
+
+        const filtered = query
+            ? augmented.filter((model) => {
+                  const idMatch = model.id.toLowerCase().includes(query);
+                  const nameMatch = model.name?.toLowerCase().includes(query) ?? false;
+                  return idMatch || nameMatch;
+              })
+            : augmented;
+
+        return filtered.sort((a, b) => {
+            if (b.usage !== a.usage) {
+                return b.usage - a.usage;
+            }
+            return a.id.localeCompare(b.id);
+        });
+    }, [models, usageCounts, searchQuery]);
+
+    const handleSelectModel = (model: ModelOption) => {
+        onSelect(model);
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-3xl">
+                <DialogHeader>
+                    <DialogTitle>Select a model for your next response</DialogTitle>
+                </DialogHeader>
+                <div className="flex flex-col gap-4">
+                    <Input
+                        placeholder="Search models..."
+                        value={searchQuery}
+                        onChange={(event) => setSearchQuery(event.target.value)}
+                        autoFocus
+                    />
+                    {error && (
+                        <p className="text-sm text-destructive">{error}</p>
+                    )}
+                    <ScrollArea className="h-[420px] rounded-md border">
+                        {loading ? (
+                            <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+                                Loading models...
+                            </div>
+                        ) : filteredModels.length === 0 ? (
+                            <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+                                No models match your search.
+                            </div>
+                        ) : (
+                            <div className="divide-y">
+                                {filteredModels.map((model) => {
+                                    const usage = model.usage;
+                                    const isSelected = selectedModelId === model.id;
+                                    return (
+                                        <button
+                                            key={model.id}
+                                            type="button"
+                                            onClick={() => handleSelectModel(model)}
+                                            className={cn(
+                                                'flex w-full items-start justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-muted',
+                                                isSelected ? 'bg-muted/70' : 'bg-background'
+                                            )}
+                                        >
+                                            <div className="space-y-1">
+                                                <p className="text-sm font-medium text-foreground">
+                                                    {model.name || model.id}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">{model.id}</p>
+                                                {model.description && (
+                                                    <p className="text-xs text-muted-foreground line-clamp-2">
+                                                        {model.description}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            <div className="flex flex-col items-end gap-2">
+                                                <Badge variant="outline" className="font-normal">
+                                                    Used {usage}×
+                                                </Badge>
+                                                {isSelected && (
+                                                    <span className="text-xs font-semibold text-primary">Selected</span>
+                                                )}
+                                            </div>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </ScrollArea>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default ModelSelectionDialog;

--- a/src/lib/modelUsage.ts
+++ b/src/lib/modelUsage.ts
@@ -1,0 +1,101 @@
+import type { ModelOption } from '@/types/models';
+
+const MODEL_USAGE_STORAGE_KEY = 'chat_model_usage_history';
+export const SELECTED_MODEL_STORAGE_KEY = 'chat_selected_model';
+const ROLLING_WINDOW_HOURS = 72;
+const ROLLING_WINDOW_MS = ROLLING_WINDOW_HOURS * 60 * 60 * 1000;
+export const PRESEEDED_USAGE_COUNT = 10;
+
+export const PRESEEDED_MODELS: Record<string, string> = {
+    'openai/gpt-5': 'OpenAI GPT-5',
+    'google/gemini-2.5-pro': 'Google Gemini 2.5 Pro',
+    'anthropic/claude-sonnet-4.5': 'Anthropic Claude Sonnet 4.5',
+    'anthropic/claude-sonnet-4': 'Anthropic Claude Sonnet 4',
+    'anthropic/claude-opus-4.1': 'Anthropic Claude Opus 4.1',
+    'x-ai/grok-4-fast': 'xAI Grok 4 Fast',
+};
+
+export const DEFAULT_MODEL: ModelOption = {
+    id: 'openai/gpt-5',
+    name: PRESEEDED_MODELS['openai/gpt-5'],
+};
+
+type UsageHistory = Record<string, number[]>;
+
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const readUsageHistory = (): UsageHistory => {
+    if (!isBrowser) return {};
+    try {
+        const stored = window.localStorage.getItem(MODEL_USAGE_STORAGE_KEY);
+        if (!stored) return {};
+        const parsed = JSON.parse(stored) as UsageHistory;
+        Object.keys(parsed).forEach((key) => {
+            parsed[key] = Array.isArray(parsed[key])
+                ? parsed[key].map((value) => Number(value)).filter((value) => !Number.isNaN(value))
+                : [];
+        });
+        return parsed;
+    } catch (error) {
+        console.warn('Failed to read model usage history:', error);
+        return {};
+    }
+};
+
+const writeUsageHistory = (history: UsageHistory) => {
+    if (!isBrowser) return;
+    try {
+        window.localStorage.setItem(MODEL_USAGE_STORAGE_KEY, JSON.stringify(history));
+    } catch (error) {
+        console.warn('Failed to persist model usage history:', error);
+    }
+};
+
+const pruneHistory = (history: UsageHistory): UsageHistory => {
+    const cutoff = Date.now() - ROLLING_WINDOW_MS;
+    const pruned: UsageHistory = {};
+
+    Object.entries(history).forEach(([modelId, timestamps]) => {
+        const recent = timestamps.filter((timestamp) => timestamp >= cutoff);
+        if (recent.length > 0) {
+            pruned[modelId] = recent;
+        }
+    });
+
+    return pruned;
+};
+
+export const recordModelUsage = (modelId: string, timestamp: number = Date.now()) => {
+    if (!isBrowser) return;
+    const history = readUsageHistory();
+    const updated = { ...history };
+    const existing = updated[modelId] ?? [];
+    updated[modelId] = [...existing, timestamp];
+    const pruned = pruneHistory(updated);
+    writeUsageHistory(pruned);
+};
+
+export const getUsageCounts = (): Record<string, number> => {
+    if (!isBrowser) return {};
+    const history = pruneHistory(readUsageHistory());
+    writeUsageHistory(history);
+
+    const result: Record<string, number> = {};
+    Object.entries(history).forEach(([modelId, timestamps]) => {
+        result[modelId] = timestamps.length;
+    });
+
+    Object.keys(PRESEEDED_MODELS).forEach((modelId) => {
+        result[modelId] = (result[modelId] ?? 0) + PRESEEDED_USAGE_COUNT;
+    });
+
+    return result;
+};
+
+export const getDisplayNameForModel = (model: ModelOption | string): string => {
+    const modelId = typeof model === 'string' ? model : model.id;
+    if (typeof model !== 'string' && model.name) {
+        return model.name;
+    }
+    return PRESEEDED_MODELS[modelId] ?? modelId;
+};

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,5 @@
+export interface ModelOption {
+    id: string;
+    name?: string;
+    description?: string;
+}


### PR DESCRIPTION
## Summary
- add a model selector button and dialog to the chat input so users can choose the model for their next response
- persist model selection and capture 72-hour usage history (with seeded defaults) to sort models and keep popular options surfaced
- update the OpenRouter client to honor the selected model and always send high-effort reasoning parameters on chat completion calls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc3628ff9083238e9091f79a9ff4c6