### PR TITLE
Align chat and layout persistence with new Supabase schema

### DIFF
--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -27,6 +27,140 @@ import { useTodayTime } from '@/hooks/useTodayTime';
 import ProgressGraphPanel from './ProgressGraphPanel';
 import StatsPanel from './StatsPanel';
 import ChatLayout from './chat/ChatLayout';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+import { useToast } from '@/hooks/use-toast';
+
+type LayoutState = {
+  vertical: number[];
+  topRow: number[];
+  bottomRow: number[];
+  chat: number[];
+};
+
+const DEFAULT_LAYOUT: LayoutState = {
+  vertical: [65, 15, 20],
+  topRow: [70, 15, 15],
+  bottomRow: [75, 25],
+  chat: [20, 80],
+};
+
+type LayoutSectionKey = keyof LayoutState;
+type LayoutBorderRow = Database['public']['Tables']['layout_borders']['Row'];
+type LayoutBorderInsert = Database['public']['Tables']['layout_borders']['Insert'];
+
+const LAYOUT_CACHE_KEY = 'layout_state_cache_v1';
+
+const BORDER_CONFIG: Record<LayoutSectionKey, { axis: 'x' | 'y'; ids: string[] }> = {
+  vertical: { axis: 'y', ids: ['vertical_top_split', 'vertical_middle_split'] },
+  topRow: { axis: 'x', ids: ['top_graph_task_split', 'top_task_calendar_split'] },
+  bottomRow: { axis: 'x', ids: ['bottom_progress_stats_split'] },
+  chat: { axis: 'x', ids: ['chat_sidebar_content_split'] },
+};
+
+const sizesToPositions = (sizes: number[]): number[] => {
+  const positions: number[] = [];
+  let total = 0;
+  for (let index = 0; index < sizes.length - 1; index += 1) {
+    const value = Number(sizes[index]);
+    total += Number.isFinite(value) ? value : 0;
+    positions.push(total);
+  }
+  return positions;
+};
+
+const positionsToSizes = (positions: number[], fallback: number[]): number[] => {
+  const total = fallback.reduce((sum, part) => sum + part, 0);
+  const sanitized: number[] = [];
+  let previous = 0;
+  positions.forEach((raw) => {
+    const numeric = Number.isFinite(raw) ? raw : previous;
+    const clamped = Math.min(Math.max(numeric, previous), total);
+    sanitized.push(clamped - previous);
+    previous = clamped;
+  });
+  sanitized.push(Math.max(total - previous, 0));
+  return sanitized;
+};
+
+const layoutToBorderUpserts = (layout: LayoutState): LayoutBorderInsert[] => {
+  const payload: LayoutBorderInsert[] = [];
+  (Object.entries(BORDER_CONFIG) as Array<[LayoutSectionKey, { axis: 'x' | 'y'; ids: string[] }]>).forEach(
+    ([section, config]) => {
+      const positions = sizesToPositions(layout[section]);
+      config.ids.forEach((id, index) => {
+        payload.push({
+          border_id: id,
+          axis: config.axis,
+          position: positions[index] ?? 0,
+        });
+      });
+    }
+  );
+  return payload;
+};
+
+const layoutFromBorderRows = (rows: LayoutBorderRow[]): LayoutState => {
+  const record = new Map(rows.map((row) => [row.border_id, row]));
+  const next: LayoutState = { ...DEFAULT_LAYOUT };
+
+  (Object.entries(BORDER_CONFIG) as Array<[LayoutSectionKey, { axis: 'x' | 'y'; ids: string[] }]>).forEach(
+    ([section, config]) => {
+      const fallback = DEFAULT_LAYOUT[section];
+      const fallbackPositions = sizesToPositions(fallback);
+      const positions = config.ids.map((id, index) => {
+        const row = record.get(id);
+        if (!row || row.axis !== config.axis) {
+          return fallbackPositions[index];
+        }
+        const numeric = Number(row.position);
+        if (!Number.isFinite(numeric)) {
+          return fallbackPositions[index];
+        }
+        return numeric;
+      });
+
+      const monotonic: number[] = [];
+      positions.forEach((value, index) => {
+        const previous = index === 0 ? 0 : monotonic[index - 1];
+        const total = fallback.reduce((sum, part) => sum + part, 0);
+        let current = value;
+        if (!Number.isFinite(current)) {
+          current = fallbackPositions[index];
+        }
+        if (current < previous) {
+          current = previous;
+        }
+        if (current > total) {
+          current = total;
+        }
+        monotonic.push(current);
+      });
+
+      next[section] = normalizeSection(positionsToSizes(monotonic, fallback), fallback);
+    }
+  );
+
+  return next;
+};
+
+const normalizeSection = (value: unknown, fallback: number[]): number[] => {
+  if (!Array.isArray(value) || value.length !== fallback.length) {
+    return [...fallback];
+  }
+  const sanitized = value.map((entry) => {
+    const num = Number(entry);
+    return Number.isFinite(num) ? num : 0;
+  });
+  return sanitized;
+};
+
+const normalizeLayout = (input?: Partial<LayoutState>): LayoutState => ({
+  vertical: normalizeSection(input?.vertical, DEFAULT_LAYOUT.vertical),
+  topRow: normalizeSection(input?.topRow, DEFAULT_LAYOUT.topRow),
+  bottomRow: normalizeSection(input?.bottomRow, DEFAULT_LAYOUT.bottomRow),
+  chat: normalizeSection(input?.chat, DEFAULT_LAYOUT.chat),
+});
 
 const nodeTypes = {
   startNode: StartNode,
@@ -66,23 +200,119 @@ export default function CausalGraph() {
   const prevMainViewportRef = useRef<{ x: number; y: number; zoom: number } | null>(null);
   const restoreOnBackRef = useRef(false);
   const { now, dayKey, startOfDay, endOfDay } = useTodayTime(60000);
-
-  // Persist panel sizes in localStorage
-  const PANEL_SIZES_KEY = 'panel_sizes_v1';
-  const [panelSizes, setPanelSizes] = useState<number[]>(() => {
+  const { toast } = useToast();
+  const highlightTimeoutRef = useRef<number | null>(null);
+  const layoutSyncTimerRef = useRef<number | null>(null);
+  const layoutLoadedRef = useRef(false);
+  const [layoutState, setLayoutState] = useState<LayoutState>(() => {
+    if (typeof window === 'undefined') {
+      return normalizeLayout();
+    }
     try {
-      const raw = localStorage.getItem(PANEL_SIZES_KEY);
-      if (!raw) return [70, 15, 15];
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed) && parsed.length === 3) return parsed;
-      return [70, 15, 15];
-    } catch {
-      return [70, 15, 15];
+      const raw = window.localStorage.getItem(LAYOUT_CACHE_KEY);
+      return normalizeLayout(raw ? JSON.parse(raw) : undefined);
+    } catch (error) {
+      console.warn('[Layout] Failed to read cached layout state', error);
+      return normalizeLayout();
     }
   });
-  const onLayout = useCallback((sizes: number[]) => {
-    setPanelSizes(sizes);
-    try { localStorage.setItem(PANEL_SIZES_KEY, JSON.stringify(sizes)); } catch { }
+  const layoutStateRef = useRef<LayoutState>(layoutState);
+  const [layoutRevision, setLayoutRevision] = useState(0);
+
+  useEffect(() => {
+    layoutStateRef.current = layoutState;
+  }, [layoutState]);
+
+  const scheduleLayoutSync = useCallback((nextLayout: LayoutState) => {
+    if (!layoutLoadedRef.current) return;
+    if (layoutSyncTimerRef.current) {
+      window.clearTimeout(layoutSyncTimerRef.current);
+    }
+    layoutSyncTimerRef.current = window.setTimeout(async () => {
+      try {
+        const payload = layoutToBorderUpserts(nextLayout);
+        if (payload.length === 0) return;
+        const { error } = await supabase.from('layout_borders').upsert(payload);
+        if (error) throw error;
+      } catch (error) {
+        console.error('[Layout] Failed to persist layout to Supabase', error);
+      }
+    }, 400);
+  }, []);
+
+  const updateLayoutSection = useCallback(
+    (section: keyof LayoutState, values: number[]) => {
+      setLayoutState((prev) => {
+        const sanitized = normalizeSection(values, DEFAULT_LAYOUT[section]);
+        const next = { ...prev, [section]: sanitized };
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(LAYOUT_CACHE_KEY, JSON.stringify(next));
+          } catch (error) {
+            console.warn('[Layout] Failed to cache layout locally', error);
+          }
+        }
+        scheduleLayoutSync(next);
+        return next;
+      });
+    },
+    [scheduleLayoutSync]
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchLayout = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('layout_borders')
+          .select('border_id, axis, position');
+        if (error) throw error;
+        if (!isMounted) return;
+
+        if (data && data.length > 0) {
+          const remote = layoutFromBorderRows(data as LayoutBorderRow[]);
+          setLayoutState(remote);
+          setLayoutRevision((rev) => rev + 1);
+        } else {
+          const payload = layoutToBorderUpserts(layoutStateRef.current);
+          if (payload.length > 0) {
+            const { error: upsertError } = await supabase
+              .from('layout_borders')
+              .upsert(payload);
+            if (upsertError) throw upsertError;
+          }
+        }
+      } catch (error) {
+        console.error('[Layout] Failed to load layout from Supabase', error);
+      } finally {
+        if (isMounted) {
+          layoutLoadedRef.current = true;
+        }
+      }
+    };
+
+    fetchLayout();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(LAYOUT_CACHE_KEY, JSON.stringify(layoutState));
+    } catch (error) {
+      console.warn('[Layout] Failed to persist layout snapshot locally', error);
+    }
+  }, [layoutState]);
+
+  useEffect(() => () => {
+    if (layoutSyncTimerRef.current) {
+      window.clearTimeout(layoutSyncTimerRef.current);
+    }
+    if (highlightTimeoutRef.current) {
+      window.clearTimeout(highlightTimeoutRef.current);
+    }
   }, []);
 
   const logViewport = useCallback((label: string) => {
@@ -285,11 +515,37 @@ export default function CausalGraph() {
   const onToggleComplete = useCallback((id: string) => setNodeStatus(id, 'completed'), [setNodeStatus]);
   const onZoomToNode = useCallback((id: string) => {
     if (!reactFlowInstance.current) return;
-    const node = reactFlowInstance.current.getNode(id);
-    if (node) {
-      reactFlowInstance.current.fitView({ nodes: [node], duration: 800, padding: 0.3 });
+    const instance = reactFlowInstance.current;
+    const node = instance.getNode(id);
+    if (!node) {
+      toast({
+        title: 'Node not found',
+        description: 'The selected item is not part of the current graph view.',
+      });
+      return;
     }
-  }, []);
+
+    instance.fitView({ nodes: [node], duration: 800, padding: 0.3 });
+    setNodes((prev) =>
+      prev.map((existing) => ({
+        ...existing,
+        selected: existing.id === id,
+      }))
+    );
+
+    if (highlightTimeoutRef.current) {
+      window.clearTimeout(highlightTimeoutRef.current);
+    }
+    highlightTimeoutRef.current = window.setTimeout(() => {
+      setNodes((prev) =>
+        prev.map((existing) =>
+          existing.id === id
+            ? { ...existing, selected: false }
+            : existing
+        )
+      );
+    }, 1600);
+  }, [setNodes, toast]);
 
   if (loading) {
     return (
@@ -304,16 +560,21 @@ export default function CausalGraph() {
 
   return (
     <div className="w-full h-[100dvh] bg-graph-background">
-      {/* Manual commit timestamp badge (manually updated by AI per commit) */}
-      <div className="absolute top-2 left-2 z-[9999] text-[10px] leading-none px-2 py-1 rounded bg-black/60 text-white border border-white/10">
-        Commit: 2025-09-17T02:45:00Z
-      </div>
-
-      <ResizablePanelGroup direction="vertical" className="h-full w-full">
-        <ResizablePanel defaultSize={65}>
-          <ResizablePanelGroup direction="horizontal" onLayout={onLayout} className="h-full">
+      <ResizablePanelGroup
+        key={`vertical-${layoutRevision}`}
+        direction="vertical"
+        onLayout={(sizes) => updateLayoutSection('vertical', sizes)}
+        className="h-full w-full"
+      >
+        <ResizablePanel defaultSize={layoutState.vertical[0]}>
+          <ResizablePanelGroup
+            key={`top-${layoutRevision}`}
+            direction="horizontal"
+            onLayout={(sizes) => updateLayoutSection('topRow', sizes)}
+            className="h-full"
+          >
             {/* Left: Main graph */}
-            <ResizablePanel defaultSize={panelSizes[0]} minSize={40} className="relative">
+            <ResizablePanel defaultSize={layoutState.topRow[0]} minSize={40} className="relative">
               <ReactFlow
                 nodes={nodesWithActions}
                 edges={edges}
@@ -343,10 +604,11 @@ export default function CausalGraph() {
                 }}
               >
                 <Controls
-                  className="bg-card border-border text-foreground p-1 [&>button]:w-6 [&>button]:h-6"
+                  className="bg-card border-border text-foreground p-2 [&>button]:w-10 [&>button]:h-10 [&>button]:rounded-md"
                   showZoom={false}
                   showFitView={true}
                   showInteractive={false}
+                  style={{ transform: 'scale(0.5)', transformOrigin: 'bottom left', bottom: 6, left: 6 }}
                 >
                   <Button
                     onClick={() => {
@@ -394,7 +656,7 @@ export default function CausalGraph() {
             <ResizableHandle withHandle />
 
             {/* Middle: Daily task checklist */}
-            <ResizablePanel defaultSize={panelSizes[1]} minSize={10} className="relative">
+            <ResizablePanel defaultSize={layoutState.topRow[1]} minSize={10} className="relative">
               <DailyTaskPanel
                 nodesById={nodesById}
                 onToggleComplete={onToggleComplete}
@@ -406,26 +668,42 @@ export default function CausalGraph() {
             <ResizableHandle withHandle />
 
             {/* Right: Daily calendar view */}
-            <ResizablePanel defaultSize={panelSizes[2]} minSize={10} className="relative">
-              <DailyCalendarPanel nodesById={nodesById} startOfDay={startOfDay} endOfDay={endOfDay} now={now} />
+            <ResizablePanel defaultSize={layoutState.topRow[2]} minSize={10} className="relative">
+              <DailyCalendarPanel
+                nodesById={nodesById}
+                startOfDay={startOfDay}
+                endOfDay={endOfDay}
+                now={now}
+                onZoomToNode={onZoomToNode}
+              />
             </ResizablePanel>
           </ResizablePanelGroup>
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={15} minSize={10}>
-          <ResizablePanelGroup direction="horizontal" className="h-full">
-            <ResizablePanel defaultSize={75} minSize={30}>
+        <ResizablePanel defaultSize={layoutState.vertical[1]} minSize={10}>
+          <ResizablePanelGroup
+            key={`bottom-${layoutRevision}`}
+            direction="horizontal"
+            onLayout={(sizes) => updateLayoutSection('bottomRow', sizes)}
+            className="h-full"
+          >
+            <ResizablePanel defaultSize={layoutState.bottomRow[0]} minSize={30}>
               <ProgressGraphPanel history={docData?.historical_progress} />
             </ResizablePanel>
             <ResizableHandle withHandle />
-            <ResizablePanel defaultSize={25} minSize={20}>
+            <ResizablePanel defaultSize={layoutState.bottomRow[1]} minSize={20}>
               <StatsPanel history={docData?.historical_progress} />
             </ResizablePanel>
           </ResizablePanelGroup>
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={20} minSize={10}>
-          <ChatLayout />
+        <ResizablePanel defaultSize={layoutState.vertical[2]} minSize={10}>
+          <ChatLayout
+            layoutKey={layoutRevision}
+            sidebarSize={layoutState.chat[0]}
+            contentSize={layoutState.chat[1]}
+            onLayout={(sizes) => updateLayoutSection('chat', sizes)}
+          />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/src/components/DailyTaskPanel.tsx
+++ b/src/components/DailyTaskPanel.tsx
@@ -1,6 +1,4 @@
 import { useMemo } from 'react';
-import { cn } from '@/lib/utils';
-import { Button } from './ui/button';
 
 type TaskPanelProps = {
     nodesById: Record<string, any>;
@@ -41,7 +39,10 @@ export default function DailyTaskPanel({ nodesById, onToggleComplete, onZoomToNo
                                     className="h-4 w-4"
                                     onChange={() => onToggleComplete(t.id)}
                                 />
-                                <button className="text-left hover:underline" onClick={() => onZoomToNode(t.id)}>
+                                <button
+                                    className="text-left hover:underline text-[0.6rem] leading-tight"
+                                    onClick={() => onZoomToNode(t.id)}
+                                >
                                     {t.label}
                                 </button>
                             </li>
@@ -56,7 +57,10 @@ export default function DailyTaskPanel({ nodesById, onToggleComplete, onZoomToNo
                         {completedToday.map((t) => (
                             <li key={t.id} className="flex items-center gap-2 opacity-80">
                                 <input type="checkbox" className="h-4 w-4" checked readOnly />
-                                <button className="text-left hover:underline" onClick={() => onZoomToNode(t.id)}>
+                                <button
+                                    className="text-left hover:underline text-[0.6rem] leading-tight"
+                                    onClick={() => onZoomToNode(t.id)}
+                                >
                                     {t.label}
                                 </button>
                             </li>

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -8,19 +8,31 @@ import { ModelSelectionProvider } from '@/hooks/modelSelectionProvider';
 import { McpProvider } from '@/hooks/mcpProvider';
 import { ConversationContextProvider } from '@/hooks/conversationContextProvider';
 
-const ChatLayout = () => {
+type ChatLayoutProps = {
+    sidebarSize?: number;
+    contentSize?: number;
+    onLayout?: (sizes: number[]) => void;
+    layoutKey?: number;
+};
+
+const ChatLayout = ({ sidebarSize = 20, contentSize = 80, onLayout, layoutKey = 0 }: ChatLayoutProps) => {
     return (
         <McpProvider>
             <ModelSelectionProvider>
                 <SystemInstructionsProvider>
                     <ConversationContextProvider>
                         <ChatProvider>
-                            <ResizablePanelGroup direction="horizontal" className="h-full w-full">
-                                <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
+                            <ResizablePanelGroup
+                                key={`chat-panels-${layoutKey}`}
+                                direction="horizontal"
+                                onLayout={onLayout}
+                                className="h-full w-full"
+                            >
+                                <ResizablePanel defaultSize={sidebarSize} minSize={15} maxSize={30}>
                                     <ChatSidebar />
                                 </ResizablePanel>
                                 <ResizableHandle withHandle />
-                                <ResizablePanel>
+                                <ResizablePanel defaultSize={contentSize}>
                                     <ChatPane />
                                 </ResizablePanel>
                             </ResizablePanelGroup>

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useChatContext } from '@/hooks/useChat';
 import { Button } from '../ui/button';
-import { PlusCircle } from 'lucide-react';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '@/lib/utils';
 
@@ -11,8 +10,7 @@ const ChatSidebar = () => {
     return (
         <div className="flex h-full flex-col bg-card p-2 text-card-foreground">
             <div className="p-2">
-                <Button onClick={createThread} className="w-full">
-                    <PlusCircle className="mr-2 h-4 w-4" />
+                <Button onClick={createThread} className="w-full justify-center">
                     New Chat
                 </Button>
             </div>

--- a/src/hooks/chatProvider.tsx
+++ b/src/hooks/chatProvider.tsx
@@ -1,88 +1,534 @@
-import { ReactNode, useState, useEffect, useCallback } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
 import {
     ChatContext,
-    Message,
-    ChatThread,
-    MessageStore,
     ChatContextValue,
+    ChatThread,
+    Message,
+    MessageStore,
 } from './chatProviderContext';
+
+type ChatThreadRow = Database['public']['Tables']['chat_threads']['Row'];
+type ChatMessageRow = Database['public']['Tables']['chat_messages']['Row'];
+type ChatDraftRow = Database['public']['Tables']['chat_drafts']['Row'];
+
+type ThreadMetadata = {
+    rootChildren?: string[];
+    selectedRootChild?: string | null;
+    selectedChildByMessageId?: Record<string, string>;
+    leafMessageId?: string | null;
+};
 
 const THREADS_STORAGE_KEY = 'chat_threads';
 const MESSAGES_STORAGE_KEY = 'chat_messages';
+const DRAFTS_STORAGE_KEY = 'chat_drafts';
+const ACTIVE_THREAD_STORAGE_KEY = 'chat_active_thread';
 
-export const ChatProvider = ({ children }: { children: ReactNode }) => {
-    const [threads, setThreads] = useState<ChatThread[]>(() => {
-        try {
-            const storedThreads = localStorage.getItem(THREADS_STORAGE_KEY);
-            if (!storedThreads) return [];
-            const parsed: ChatThread[] = JSON.parse(storedThreads);
-            return parsed.map((thread) => {
-                const rootChildren = thread.rootChildren || [];
-                return {
-                    ...thread,
-                    createdAt: thread.createdAt ? new Date(thread.createdAt) : new Date(),
-                    selectedChildByMessageId: thread.selectedChildByMessageId || {},
-                    rootChildren,
-                    selectedRootChild: thread.selectedRootChild ?? rootChildren[rootChildren.length - 1],
-                };
-            });
-        } catch (e) {
-            console.error("Failed to parse threads from localStorage", e);
-            return [];
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const safeParseJSON = <T,>(value: string | null): T | null => {
+    if (!value) return null;
+    try {
+        return JSON.parse(value) as T;
+    } catch (error) {
+        console.warn('[ChatProvider] Failed to parse JSON from localStorage', error);
+        return null;
+    }
+};
+
+const rehydrateThreads = (threads: ChatThread[]): ChatThread[] =>
+    threads.map((thread) => {
+        const rootChildren = Array.isArray(thread.rootChildren) ? [...thread.rootChildren] : [];
+        const selectedChildByMessageId =
+            thread.selectedChildByMessageId && typeof thread.selectedChildByMessageId === 'object'
+                ? { ...thread.selectedChildByMessageId }
+                : {};
+        const selectedRootChild =
+            typeof thread.selectedRootChild === 'string' && rootChildren.includes(thread.selectedRootChild)
+                ? thread.selectedRootChild
+                : rootChildren[rootChildren.length - 1];
+
+        return {
+            ...thread,
+            createdAt: thread.createdAt ? new Date(thread.createdAt) : new Date(),
+            rootChildren,
+            selectedChildByMessageId,
+            selectedRootChild,
+            leafMessageId: thread.leafMessageId ?? null,
+        };
+    });
+
+const rehydrateMessages = (raw: MessageStore): MessageStore => {
+    const result: MessageStore = {};
+    Object.entries(raw || {}).forEach(([id, value]) => {
+        if (!value) return;
+        result[id] = {
+            ...value,
+            threadId: value.threadId ?? '',
+            children: Array.isArray(value.children) ? [...value.children] : [],
+            toolCalls: Array.isArray(value.toolCalls) ? [...value.toolCalls] : [],
+        };
+    });
+    return result;
+};
+
+const assignThreadIds = (threads: ChatThread[], messages: MessageStore): MessageStore => {
+    const assigned: MessageStore = {};
+    const visited = new Set<string>();
+
+    const visit = (threadId: string, messageId: string) => {
+        if (visited.has(messageId)) return;
+        const message = messages[messageId];
+        if (!message) return;
+        visited.add(messageId);
+        assigned[messageId] = {
+            ...message,
+            threadId,
+            children: [...message.children],
+            toolCalls: Array.isArray(message.toolCalls) ? [...message.toolCalls] : [],
+        };
+        message.children.forEach((childId) => visit(threadId, childId));
+    };
+
+    threads.forEach((thread) => {
+        thread.rootChildren.forEach((rootId) => visit(thread.id, rootId));
+    });
+
+    Object.entries(messages).forEach(([id, message]) => {
+        if (assigned[id]) return;
+        assigned[id] = {
+            ...message,
+            threadId: message.threadId || '',
+            children: [...message.children],
+            toolCalls: Array.isArray(message.toolCalls) ? [...message.toolCalls] : [],
+        };
+    });
+
+    return assigned;
+};
+
+const normalizeToolCalls = (value: unknown): Message['toolCalls'] => {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+        return value as Message['toolCalls'];
+    }
+    return [];
+};
+
+const resolveLeafId = (
+    thread: Pick<ChatThread, 'rootChildren' | 'selectedRootChild' | 'selectedChildByMessageId'>,
+    messages: MessageStore
+): string | null => {
+    const visited = new Set<string>();
+    let current: string | null =
+        thread.selectedRootChild ?? thread.rootChildren[thread.rootChildren.length - 1] ?? null;
+
+    while (current) {
+        if (visited.has(current)) break;
+        visited.add(current);
+        const message = messages[current];
+        if (!message) break;
+        if (message.children.length === 0) break;
+        const preferred = thread.selectedChildByMessageId[current];
+        const next =
+            preferred && message.children.includes(preferred)
+                ? preferred
+                : message.children[message.children.length - 1];
+        if (!next) break;
+        current = next;
+    }
+
+    return current;
+};
+
+const threadMetadataFromThread = (thread: ChatThread): ThreadMetadata => {
+    const metadata: ThreadMetadata = {
+        rootChildren: [...thread.rootChildren],
+        selectedRootChild: thread.selectedRootChild ?? null,
+        selectedChildByMessageId: { ...thread.selectedChildByMessageId },
+        leafMessageId: thread.leafMessageId ?? null,
+    };
+    Object.entries(metadata.selectedChildByMessageId!).forEach(([parentId, childId]) => {
+        if (typeof childId !== 'string' || !childId) {
+            delete metadata.selectedChildByMessageId![parentId];
+        }
+    });
+    return metadata;
+};
+
+const buildStateFromRemote = (
+    threadRows: ChatThreadRow[] | null,
+    messageRows: ChatMessageRow[] | null,
+    draftRows: ChatDraftRow[] | null
+) => {
+    const sortedMessages = [...(messageRows ?? [])].sort((a, b) => {
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+        return aTime - bTime;
+    });
+
+    const messages: MessageStore = {};
+    const childrenByParent = new Map<string, string[]>();
+    const rootChildrenByThread = new Map<string, string[]>();
+
+    sortedMessages.forEach((row) => {
+        messages[row.id] = {
+            id: row.id,
+            threadId: row.thread_id,
+            parentId: row.parent_id,
+            role: row.role as Message['role'],
+            content: row.content ?? '',
+            thinking: row.thinking ?? undefined,
+            children: [],
+            toolCalls: normalizeToolCalls(row.tool_calls),
+        };
+
+        if (row.parent_id) {
+            const list = childrenByParent.get(row.parent_id) ?? [];
+            list.push(row.id);
+            childrenByParent.set(row.parent_id, list);
+        } else {
+            const list = rootChildrenByThread.get(row.thread_id) ?? [];
+            list.push(row.id);
+            rootChildrenByThread.set(row.thread_id, list);
         }
     });
 
-    const [messages, setMessages] = useState<MessageStore>(() => {
-        try {
-            const storedMessages = localStorage.getItem(MESSAGES_STORAGE_KEY);
-            if (!storedMessages) return {};
-            const parsed: MessageStore = JSON.parse(storedMessages);
-            Object.keys(parsed).forEach((id) => {
-                parsed[id].children = parsed[id].children || [];
-                parsed[id].toolCalls = parsed[id].toolCalls || [];
-            });
-            return parsed;
-        } catch (e) {
-            console.error("Failed to parse messages from localStorage", e);
-            return {};
+    childrenByParent.forEach((childIds, parentId) => {
+        if (messages[parentId]) {
+            messages[parentId].children = [...childIds];
         }
     });
 
-    const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+    const threads: ChatThread[] = (threadRows ?? []).map((row) => {
+        const metadata = (row.metadata as ThreadMetadata | null) ?? {};
+        const fallbackRoots = rootChildrenByThread.get(row.id) ?? [];
+        const metadataRoots = Array.isArray(metadata.rootChildren)
+            ? metadata.rootChildren.filter((id): id is string => typeof id === 'string' && !!messages[id])
+            : [];
 
-    // Save to localStorage whenever threads or messages change
+        const rootChildren: string[] = [];
+        metadataRoots.forEach((id) => {
+            if (messages[id] && !rootChildren.includes(id)) {
+                rootChildren.push(id);
+            }
+        });
+        fallbackRoots.forEach((id) => {
+            if (messages[id] && !rootChildren.includes(id)) {
+                rootChildren.push(id);
+            }
+        });
+
+        const selection: Record<string, string> = {};
+        if (metadata.selectedChildByMessageId && typeof metadata.selectedChildByMessageId === 'object') {
+            Object.entries(metadata.selectedChildByMessageId).forEach(([parentId, childId]) => {
+                if (
+                    typeof childId === 'string' &&
+                    childId &&
+                    messages[parentId]?.children.includes(childId)
+                ) {
+                    selection[parentId] = childId;
+                }
+            });
+        }
+
+        let selectedRootChild: string | undefined;
+        if (
+            metadata.selectedRootChild &&
+            typeof metadata.selectedRootChild === 'string' &&
+            rootChildren.includes(metadata.selectedRootChild)
+        ) {
+            selectedRootChild = metadata.selectedRootChild;
+        } else if (rootChildren.length > 0) {
+            selectedRootChild = rootChildren[rootChildren.length - 1];
+        }
+
+        const thread: ChatThread = {
+            id: row.id,
+            title: row.title ?? 'Untitled',
+            createdAt: row.created_at ? new Date(row.created_at) : new Date(),
+            leafMessageId: null,
+            selectedChildByMessageId: selection,
+            rootChildren,
+            selectedRootChild,
+        };
+
+        const metadataLeaf = metadata.leafMessageId;
+        if (metadataLeaf && typeof metadataLeaf === 'string' && messages[metadataLeaf]) {
+            thread.leafMessageId = metadataLeaf;
+        } else {
+            thread.leafMessageId = resolveLeafId(thread, messages);
+        }
+
+        return thread;
+    });
+
+    const messagesWithThreads = assignThreadIds(threads, messages);
+
+    const drafts: Record<string, string> = {};
+    (draftRows ?? []).forEach((row) => {
+        if (row.draft_text) {
+            drafts[row.thread_id] = row.draft_text;
+        }
+    });
+
+    return { threads, messages: messagesWithThreads, drafts };
+};
+
+const messageToRow = (message: Message): Database['public']['Tables']['chat_messages']['Insert'] => ({
+    id: message.id,
+    thread_id: message.threadId,
+    parent_id: message.parentId,
+    role: message.role,
+    content: message.content,
+    thinking: message.thinking ?? null,
+    tool_calls: message.toolCalls && message.toolCalls.length > 0 ? message.toolCalls : message.toolCalls ? [] : null,
+});
+
+const ChatProvider = ({ children }: { children: ReactNode }) => {
+    const storedThreads = rehydrateThreads(
+        safeParseJSON<ChatThread[]>(isBrowser ? window.localStorage.getItem(THREADS_STORAGE_KEY) : null) || []
+    );
+    const storedMessages = rehydrateMessages(
+        safeParseJSON<MessageStore>(isBrowser ? window.localStorage.getItem(MESSAGES_STORAGE_KEY) : null) || {}
+    );
+    const storedDrafts =
+        safeParseJSON<Record<string, string>>(isBrowser ? window.localStorage.getItem(DRAFTS_STORAGE_KEY) : null) || {};
+    const storedActiveThread = (() => {
+        if (!isBrowser) return null;
+        const raw = window.localStorage.getItem(ACTIVE_THREAD_STORAGE_KEY);
+        if (!raw || raw === 'null') return null;
+        return raw;
+    })();
+
+    const initialMessages = assignThreadIds(storedThreads, storedMessages);
+
+    const [threads, setThreads] = useState<ChatThread[]>(storedThreads);
+    const [messages, setMessages] = useState<MessageStore>(initialMessages);
+    const [drafts, setDrafts] = useState<Record<string, string>>(storedDrafts);
+    const [activeThreadId, setActiveThreadIdState] = useState<string | null>(storedActiveThread);
+
+    const pendingTasksRef = useRef<Array<() => Promise<void>>>([]);
+    const processingTasksRef = useRef(false);
+    const retryTimerRef = useRef<number | null>(null);
+
+    const clearRetryTimer = useCallback(() => {
+        if (!isBrowser) return;
+        if (retryTimerRef.current) {
+            window.clearTimeout(retryTimerRef.current);
+            retryTimerRef.current = null;
+        }
+    }, []);
+
+    const flushPending = useCallback(async () => {
+        if (processingTasksRef.current) return;
+        if (pendingTasksRef.current.length === 0) return;
+        processingTasksRef.current = true;
+        clearRetryTimer();
+        try {
+            while (pendingTasksRef.current.length > 0) {
+                const task = pendingTasksRef.current.shift();
+                if (!task) break;
+                try {
+                    await task();
+                } catch (error) {
+                    console.error('[ChatProvider] Pending Supabase task failed, retrying later', error);
+                    pendingTasksRef.current.unshift(task);
+                    if (isBrowser) {
+                        retryTimerRef.current = window.setTimeout(() => {
+                            flushPending();
+                        }, 2000);
+                    }
+                    return;
+                }
+            }
+        } finally {
+            processingTasksRef.current = false;
+        }
+    }, [clearRetryTimer]);
+
+    const scheduleTask = useCallback(
+        async (task: () => Promise<void>) => {
+            try {
+                await task();
+            } catch (error) {
+                console.error('[ChatProvider] Supabase operation failed, queuing for retry', error);
+                pendingTasksRef.current.push(task);
+                if (isBrowser) {
+                    clearRetryTimer();
+                    retryTimerRef.current = window.setTimeout(() => {
+                        flushPending();
+                    }, 2000);
+                }
+            }
+        },
+        [clearRetryTimer, flushPending]
+    );
+
     useEffect(() => {
+        if (!isBrowser) return;
+        const handleOnline = () => {
+            flushPending();
+        };
+        window.addEventListener('online', handleOnline);
+        return () => window.removeEventListener('online', handleOnline);
+    }, [flushPending]);
+
+    useEffect(() => () => {
+        clearRetryTimer();
+    }, [clearRetryTimer]);
+
+    useEffect(() => {
+        let isMounted = true;
+        const loadRemote = async () => {
+            try {
+                const [threadsRes, messagesRes, draftsRes] = await Promise.all([
+                    supabase.from('chat_threads').select('id, title, metadata, created_at'),
+                    supabase
+                        .from('chat_messages')
+                        .select('id, thread_id, parent_id, role, content, thinking, tool_calls, created_at'),
+                    supabase.from('chat_drafts').select('thread_id, draft_text'),
+                ]);
+
+                if (!isMounted) return;
+
+                if (threadsRes.error) throw threadsRes.error;
+                if (messagesRes.error) throw messagesRes.error;
+                if (draftsRes.error) throw draftsRes.error;
+
+                const remoteState = buildStateFromRemote(
+                    threadsRes.data ?? [],
+                    messagesRes.data ?? [],
+                    draftsRes.data ?? []
+                );
+
+                setThreads(remoteState.threads);
+                setMessages(remoteState.messages);
+                setDrafts(remoteState.drafts);
+
+                if (remoteState.threads.length > 0) {
+                    setActiveThreadIdState((current) => {
+                        if (current && remoteState.threads.some((thread) => thread.id === current)) {
+                            return current;
+                        }
+                        return remoteState.threads[0]?.id ?? null;
+                    });
+                }
+            } catch (error) {
+                console.error('[ChatProvider] Failed to load chat data from Supabase', error);
+            } finally {
+                if (isMounted) {
+                    // Remote load attempt complete; process any queued tasks.
+                    flushPending();
+                }
+            }
+        };
+
+        loadRemote();
+        return () => {
+            isMounted = false;
+        };
+    }, [flushPending]);
+
+    useEffect(() => {
+        if (!isBrowser) return;
         try {
-            localStorage.setItem(THREADS_STORAGE_KEY, JSON.stringify(threads));
-        } catch (e) {
-            console.error("Failed to save threads to localStorage", e);
+            window.localStorage.setItem(THREADS_STORAGE_KEY, JSON.stringify(threads));
+        } catch (error) {
+            console.error('[ChatProvider] Failed to save threads to localStorage', error);
         }
     }, [threads]);
 
     useEffect(() => {
+        if (!isBrowser) return;
         try {
-            localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(messages));
-        } catch (e) {
-            console.error("Failed to save messages to localStorage", e);
+            window.localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(messages));
+        } catch (error) {
+            console.error('[ChatProvider] Failed to save messages to localStorage', error);
         }
     }, [messages]);
 
+    useEffect(() => {
+        if (!isBrowser) return;
+        try {
+            window.localStorage.setItem(DRAFTS_STORAGE_KEY, JSON.stringify(drafts));
+        } catch (error) {
+            console.error('[ChatProvider] Failed to save drafts to localStorage', error);
+        }
+    }, [drafts]);
+
+    useEffect(() => {
+        if (!isBrowser) return;
+        try {
+            if (activeThreadId) {
+                window.localStorage.setItem(ACTIVE_THREAD_STORAGE_KEY, activeThreadId);
+            } else {
+                window.localStorage.removeItem(ACTIVE_THREAD_STORAGE_KEY);
+            }
+        } catch (error) {
+            console.error('[ChatProvider] Failed to save activeThreadId to localStorage', error);
+        }
+    }, [activeThreadId]);
+
+    const setActiveThreadId = useCallback((id: string | null) => {
+        setActiveThreadIdState(id);
+    }, []);
 
     const getThread = useCallback((id: string) => threads.find((t) => t.id === id), [threads]);
 
-    const getMessageChain = useCallback((leafId: string | null): Message[] => {
-        if (!leafId) return [];
-        const chain: Message[] = [];
-        let currentId: string | null = leafId;
-        while (currentId) {
-            const message = messages[currentId];
-            if (!message) break;
-            chain.unshift(message);
-            currentId = message.parentId;
-        }
-        return chain;
-    }, [messages]);
+    const getMessageChain = useCallback(
+        (leafId: string | null): Message[] => {
+            if (!leafId) return [];
+            const chain: Message[] = [];
+            let currentId: string | null = leafId;
+            const visited = new Set<string>();
+            while (currentId && !visited.has(currentId)) {
+                visited.add(currentId);
+                const message = messages[currentId];
+                if (!message) break;
+                chain.unshift(message);
+                currentId = message.parentId;
+            }
+            return chain;
+        },
+        [messages]
+    );
+
+    const persistThread = useCallback(
+        (thread: ChatThread) =>
+            scheduleTask(async () => {
+                const { error } = await supabase.from('chat_threads').upsert({
+                    id: thread.id,
+                    title: thread.title,
+                    metadata: threadMetadataFromThread(thread),
+                });
+                if (error) throw error;
+            }),
+        [scheduleTask]
+    );
+
+    const persistMessage = useCallback(
+        (message: Message) =>
+            scheduleTask(async () => {
+                const { error } = await supabase.from('chat_messages').upsert(messageToRow(message));
+                if (error) throw error;
+            }),
+        [scheduleTask]
+    );
+
+    const persistDraft = useCallback(
+        (threadId: string, content: string) =>
+            scheduleTask(async () => {
+                const { error } = await supabase.from('chat_drafts').upsert({
+                    thread_id: threadId,
+                    draft_text: content,
+                });
+                if (error) throw error;
+            }),
+        [scheduleTask]
+    );
 
     const createThread = useCallback(() => {
         const newThread: ChatThread = {
@@ -92,21 +538,26 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
             createdAt: new Date(),
             selectedChildByMessageId: {},
             rootChildren: [],
+            selectedRootChild: undefined,
         };
         setThreads((prev) => [...prev, newThread]);
-        setActiveThreadId(newThread.id);
+        setActiveThreadIdState(newThread.id);
+        setDrafts((prev) => ({ ...prev, [newThread.id]: '' }));
+        persistThread(newThread);
+        persistDraft(newThread.id, '');
         return newThread.id;
-    }, []);
+    }, [persistDraft, persistThread]);
 
     const addMessage = useCallback(
         (
             threadId: string,
-            messageData: Omit<Message, 'id' | 'children' | 'toolCalls'>
+            messageData: Omit<Message, 'id' | 'children' | 'threadId'>
         ): Message => {
             const newId = uuidv4();
             const newMessage: Message = {
                 ...messageData,
                 id: newId,
+                threadId,
                 children: [],
                 toolCalls: messageData.toolCalls ? [...messageData.toolCalls] : [],
             };
@@ -116,114 +567,185 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
                     ...prev,
                     [newId]: newMessage,
                 };
-                if (messageData.parentId && prev[messageData.parentId]) {
-                    updated[messageData.parentId] = {
-                        ...prev[messageData.parentId],
-                        children: [...prev[messageData.parentId].children, newId],
+                if (newMessage.parentId && prev[newMessage.parentId]) {
+                    updated[newMessage.parentId] = {
+                        ...prev[newMessage.parentId],
+                        children: [...prev[newMessage.parentId].children, newId],
                     };
                 }
                 return updated;
             });
 
+            let threadForPersist: ChatThread | null = null;
             setThreads((prev) =>
                 prev.map((thread) => {
                     if (thread.id !== threadId) return thread;
 
                     const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
-                    let rootChildren = thread.rootChildren ? [...thread.rootChildren] : [];
+                    let rootChildren = [...thread.rootChildren];
                     let selectedRootChild = thread.selectedRootChild;
 
-                    if (messageData.parentId) {
-                        selectedChildByMessageId[messageData.parentId] = newId;
+                    if (newMessage.parentId) {
+                        selectedChildByMessageId[newMessage.parentId] = newId;
                     } else {
                         rootChildren = [...rootChildren, newId];
                         selectedRootChild = newId;
                     }
 
-                    return {
+                    const nextThread: ChatThread = {
                         ...thread,
                         title:
-                            thread.title === 'New Chat' && messageData.role === 'user'
-                                ? `${messageData.content.substring(0, 30)}...`
+                            thread.title === 'New Chat' && newMessage.role === 'user'
+                                ? `${newMessage.content.substring(0, 30)}...`
                                 : thread.title,
                         leafMessageId: newId,
                         selectedChildByMessageId,
                         rootChildren,
                         selectedRootChild,
                     };
+                    threadForPersist = nextThread;
+                    return nextThread;
                 })
             );
+
+            if (threadForPersist) {
+                persistThread(threadForPersist);
+            }
+            persistMessage(newMessage);
             return newMessage;
         },
-        []
+        [persistMessage, persistThread]
     );
 
-    const updateMessage = useCallback((messageId: string, updates: Partial<Message> | ((message: Message) => Partial<Message>)) => {
-        setMessages((prev) => {
-            const current = prev[messageId];
-            if (!current) {
-                console.warn(`[ChatProvider] Attempted to update non-existent message: ${messageId}`);
-                return prev;
-            }
-            const appliedUpdates = typeof updates === 'function' ? updates(current) : updates;
-            const updatedMessages = {
-                ...prev,
-                [messageId]: {
+    const updateMessage = useCallback(
+        (
+            messageId: string,
+            updates: Partial<Message> | ((message: Message) => Partial<Message>)
+        ) => {
+            let updatedMessage: Message | null = null;
+            setMessages((prev) => {
+                const current = prev[messageId];
+                if (!current) {
+                    console.warn(`[ChatProvider] Attempted to update non-existent message: ${messageId}`);
+                    return prev;
+                }
+                const appliedUpdates =
+                    typeof updates === 'function' ? updates(current) : updates;
+                updatedMessage = {
                     ...current,
                     ...appliedUpdates,
-                },
-            };
-            return updatedMessages;
-        });
-    }, []);
-
-    const selectBranch = useCallback((threadId: string | null, parentId: string | null, childId: string) => {
-        if (!threadId) return;
-        setThreads((prev) =>
-            prev.map((thread) => {
-                if (thread.id !== threadId) return thread;
-
-                const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
-                let selectedRootChild = thread.selectedRootChild;
-
-                if (parentId) {
-                    selectedChildByMessageId[parentId] = childId;
-                } else {
-                    selectedRootChild = childId;
-                }
-
-                let nextLeaf: string | undefined | null = childId;
-                const visited = new Set<string>();
-
-                while (nextLeaf && !visited.has(nextLeaf)) {
-                    visited.add(nextLeaf);
-                    const message = messages[nextLeaf];
-                    if (!message || message.children.length === 0) break;
-                    const selectedChild = selectedChildByMessageId[nextLeaf] ?? message.children[message.children.length - 1];
-                    selectedChildByMessageId[nextLeaf] = selectedChild;
-                    nextLeaf = selectedChild;
-                }
-
-                return {
-                    ...thread,
-                    selectedChildByMessageId,
-                    selectedRootChild,
-                    leafMessageId: nextLeaf || childId,
                 };
-            })
-        );
-    }, [messages]);
+                return {
+                    ...prev,
+                    [messageId]: updatedMessage!,
+                };
+            });
 
-    const updateThreadTitle = useCallback((threadId: string, title: string) => {
-        setThreads((prev) =>
-            prev.map((thread) => (thread.id === threadId ? { ...thread, title } : thread))
-        );
-    }, []);
+            if (updatedMessage) {
+                persistMessage(updatedMessage);
+            }
+        },
+        [persistMessage]
+    );
+
+    const selectBranch = useCallback(
+        (threadId: string | null, parentId: string | null, childId: string) => {
+            if (!threadId) return;
+            let threadForPersist: ChatThread | null = null;
+            setThreads((prev) =>
+                prev.map((thread) => {
+                    if (thread.id !== threadId) return thread;
+
+                    const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
+                    let selectedRootChild = thread.selectedRootChild;
+
+                    if (parentId) {
+                        selectedChildByMessageId[parentId] = childId;
+                    } else {
+                        selectedRootChild = childId;
+                    }
+
+                    let nextLeaf: string | null = childId;
+                    const visited = new Set<string>();
+
+                    while (nextLeaf && !visited.has(nextLeaf)) {
+                        visited.add(nextLeaf);
+                        const message = messages[nextLeaf];
+                        if (!message || message.children.length === 0) break;
+                        const selectedChild =
+                            selectedChildByMessageId[nextLeaf] ??
+                            message.children[message.children.length - 1];
+                        if (!selectedChild) break;
+                        selectedChildByMessageId[nextLeaf] = selectedChild;
+                        nextLeaf = selectedChild;
+                    }
+
+                    const nextThread: ChatThread = {
+                        ...thread,
+                        selectedChildByMessageId,
+                        selectedRootChild,
+                        leafMessageId: nextLeaf || childId,
+                    };
+                    threadForPersist = nextThread;
+                    return nextThread;
+                })
+            );
+
+            if (threadForPersist) {
+                persistThread(threadForPersist);
+            }
+        },
+        [messages, persistThread]
+    );
+
+    const updateThreadTitle = useCallback(
+        (threadId: string, title: string) => {
+            let threadForPersist: ChatThread | null = null;
+            setThreads((prev) =>
+                prev.map((thread) => {
+                    if (thread.id !== threadId) return thread;
+                    const nextThread = { ...thread, title };
+                    threadForPersist = nextThread;
+                    return nextThread;
+                })
+            );
+            if (threadForPersist) {
+                persistThread(threadForPersist);
+            }
+        },
+        [persistThread]
+    );
+
+    const setDraft = useCallback(
+        (threadId: string, content: string) => {
+            setDrafts((prev) => {
+                const next = { ...prev };
+                if (!content) {
+                    if (next[threadId]) {
+                        delete next[threadId];
+                    }
+                } else {
+                    next[threadId] = content;
+                }
+                return next;
+            });
+            persistDraft(threadId, content);
+        },
+        [persistDraft]
+    );
+
+    const clearDraft = useCallback(
+        (threadId: string) => {
+            setDraft(threadId, '');
+        },
+        [setDraft]
+    );
 
     const value: ChatContextValue = {
         threads,
         messages,
         activeThreadId,
+        drafts,
         setActiveThreadId,
         getThread,
         createThread,
@@ -232,7 +754,11 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         updateMessage,
         selectBranch,
         updateThreadTitle,
+        setDraft,
+        clearDraft,
     };
 
     return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
 };
+
+export { ChatProvider };

--- a/src/hooks/chatProviderContext.ts
+++ b/src/hooks/chatProviderContext.ts
@@ -11,8 +11,9 @@ export interface ToolCallState {
 
 export interface Message {
     id: string;
-    parentId: string | null; 
-    role: 'user' | 'assistant';
+    threadId: string;
+    parentId: string | null;
+    role: 'system' | 'user' | 'assistant' | 'tool';
     content: string;
     thinking?: string;
     children: string[];
@@ -35,15 +36,24 @@ export interface ChatContextValue {
     threads: ChatThread[];
     messages: MessageStore;
     activeThreadId: string | null;
-    
+    drafts: Record<string, string>;
+
     setActiveThreadId: (id: string | null) => void;
     getThread: (id: string) => ChatThread | undefined;
     createThread: () => string;
-    addMessage: (threadId: string, message: Omit<Message, 'id' | 'children'>) => Message;
+    addMessage: (
+        threadId: string,
+        message: Omit<Message, 'id' | 'children' | 'threadId'>
+    ) => Message;
     getMessageChain: (leafId: string | null) => Message[];
-    updateMessage: (messageId: string, updates: Partial<Message>) => void;
+    updateMessage: (
+        messageId: string,
+        updates: Partial<Message> | ((message: Message) => Partial<Message>)
+    ) => void;
     selectBranch: (threadId: string | null, parentId: string | null, childId: string) => void;
     updateThreadTitle: (threadId: string, title: string) => void;
+    setDraft: (threadId: string, content: string) => void;
+    clearDraft: (threadId: string) => void;
 }
 
 export const ChatContext = createContext<ChatContextValue | undefined>(undefined);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -107,6 +107,128 @@ export type Database = {
         }
         Relationships: []
       }
+      chat_drafts: {
+        Row: {
+          draft_text: string
+          thread_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          draft_text?: string
+          thread_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          draft_text?: string
+          thread_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_drafts_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: true
+            referencedRelation: "chat_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_messages: {
+        Row: {
+          content: string
+          created_at: string | null
+          id: string
+          parent_id: string | null
+          role: string
+          thread_id: string
+          thinking: string | null
+          tool_calls: Json | null
+          updated_at: string | null
+        }
+        Insert: {
+          content: string
+          created_at?: string | null
+          id?: string
+          parent_id?: string | null
+          role: string
+          thread_id: string
+          thinking?: string | null
+          tool_calls?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          content?: string
+          created_at?: string | null
+          id?: string
+          parent_id?: string | null
+          role?: string
+          thread_id?: string
+          thinking?: string | null
+          tool_calls?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_messages_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "chat_messages"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "chat_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_threads: {
+        Row: {
+          created_at: string | null
+          id: string
+          metadata: Json | null
+          title: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          metadata?: Json | null
+          title: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          metadata?: Json | null
+          title?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      layout_borders: {
+        Row: {
+          axis: string
+          border_id: string
+          position: number
+          updated_at: string | null
+        }
+        Insert: {
+          axis: string
+          border_id: string
+          position: number
+          updated_at?: string | null
+        }
+        Update: {
+          axis?: string
+          border_id?: string
+          position?: number
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       nodes: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250917083000_add_chat_and_layout_documents.sql
+++ b/supabase/migrations/20250917083000_add_chat_and_layout_documents.sql
@@ -1,0 +1,28 @@
+create table if not exists public.chat_documents (
+    id text primary key,
+    data jsonb not null,
+    version bigint not null default 0,
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.layout_state (
+    id text primary key,
+    data jsonb not null,
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.touch_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = timezone('utc', now());
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger chat_documents_set_updated
+    before update on public.chat_documents
+    for each row execute function public.touch_updated_at();
+
+create trigger layout_state_set_updated
+    before update on public.layout_state
+    for each row execute function public.touch_updated_at();

--- a/supabase/migrations/20250925090000_align_chat_and_layout_schema.sql
+++ b/supabase/migrations/20250925090000_align_chat_and_layout_schema.sql
@@ -1,0 +1,67 @@
+-- Align chat and layout persistence with the normalized table structure
+
+-- Drop legacy aggregates if they exist
+drop table if exists public.chat_documents;
+drop table if exists public.layout_state;
+
+-- Ensure helper for updated_at is present
+create or replace function public.touch_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = timezone('utc', now());
+    return new;
+end;
+$$ language plpgsql;
+
+-- Chat threads store metadata for branch selections and timestamps
+create table if not exists public.chat_threads (
+    id uuid primary key default gen_random_uuid(),
+    title text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger chat_threads_set_updated
+    before update on public.chat_threads
+    for each row execute function public.touch_updated_at();
+
+-- Individual chat messages with branching via parent_id
+create table if not exists public.chat_messages (
+    id uuid primary key default gen_random_uuid(),
+    thread_id uuid not null references public.chat_threads(id) on delete cascade,
+    parent_id uuid references public.chat_messages(id) on delete cascade,
+    role text not null check (role in ('system', 'user', 'assistant', 'tool')),
+    content text not null,
+    thinking text,
+    tool_calls jsonb,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger chat_messages_set_updated
+    before update on public.chat_messages
+    for each row execute function public.touch_updated_at();
+
+-- Draft text per thread (single row)
+create table if not exists public.chat_drafts (
+    thread_id uuid primary key references public.chat_threads(id) on delete cascade,
+    draft_text text not null default '',
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger chat_drafts_set_updated
+    before update on public.chat_drafts
+    for each row execute function public.touch_updated_at();
+
+-- Layout border positions per adjustable divider
+create table if not exists public.layout_borders (
+    border_id text primary key,
+    axis text not null check (axis in ('x', 'y')),
+    position double precision not null,
+    updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger layout_borders_set_updated
+    before update on public.layout_borders
+    for each row execute function public.touch_updated_at();


### PR DESCRIPTION
## Summary
- refactor the chat provider to hydrate threads, messages, and drafts from the new `chat_threads`, `chat_messages`, and `chat_drafts` tables with per-row Supabase upserts, queued retries, and thread-aware message metadata
- extend the chat context message shape to include thread identifiers and full role coverage while persisting layout sizing through the normalized `layout_borders` dividers instead of the old JSON document
- update Supabase types and add a migration that drops the legacy aggregates and creates the authoritative chat and layout tables with triggers

## Testing
- npm run build *(fails: existing ESLint any violations in legacy files)*
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dd6b6e5d008323ba8e6c17d7fed313