### PR TITLE
Implement Supabase-backed chat sync and layout persistence

### DIFF
--- a/src/components/DailyTaskPanel.tsx
+++ b/src/components/DailyTaskPanel.tsx
@@ -41,7 +41,10 @@ export default function DailyTaskPanel({ nodesById, onToggleComplete, onZoomToNo
                                     className="h-4 w-4"
                                     onChange={() => onToggleComplete(t.id)}
                                 />
-                                <button className="text-left hover:underline" onClick={() => onZoomToNode(t.id)}>
+                                <button
+                                    className="text-left hover:underline text-[0.6rem] leading-4"
+                                    onClick={() => onZoomToNode(t.id)}
+                                >
                                     {t.label}
                                 </button>
                             </li>
@@ -56,7 +59,10 @@ export default function DailyTaskPanel({ nodesById, onToggleComplete, onZoomToNo
                         {completedToday.map((t) => (
                             <li key={t.id} className="flex items-center gap-2 opacity-80">
                                 <input type="checkbox" className="h-4 w-4" checked readOnly />
-                                <button className="text-left hover:underline" onClick={() => onZoomToNode(t.id)}>
+                                <button
+                                    className="text-left hover:underline text-[0.6rem] leading-4"
+                                    onClick={() => onZoomToNode(t.id)}
+                                >
                                     {t.label}
                                 </button>
                             </li>

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
 import ChatSidebar from './ChatSidebar';
 import ChatPane from './ChatPane';
@@ -7,20 +7,64 @@ import { SystemInstructionsProvider } from '@/hooks/systemInstructionProvider';
 import { ModelSelectionProvider } from '@/hooks/modelSelectionProvider';
 import { McpProvider } from '@/hooks/mcpProvider';
 import { ConversationContextProvider } from '@/hooks/conversationContextProvider';
+import { loadLayoutBorders, saveLayoutBorders, LayoutBorderId } from '@/services/layoutPersistence';
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const normalizeChatSizes = (position?: number | null, fallback: [number, number] = [20, 80]): [number, number] => {
+    const safeFirst = clamp(
+        typeof position === 'number' && !Number.isNaN(position) ? position : fallback[0],
+        15,
+        30
+    );
+    return [safeFirst, 100 - safeFirst];
+};
 
 const ChatLayout = () => {
+    const [chatSizes, setChatSizes] = useState<[number, number]>([20, 80]);
+    const [layoutKey, setLayoutKey] = useState(0);
+
+    useEffect(() => {
+        let cancelled = false;
+        const hydrate = async () => {
+            const borders = await loadLayoutBorders();
+            if (cancelled) return;
+            const nextSizes = normalizeChatSizes(borders[LayoutBorderId.ChatSidebar]?.position, [20, 80]);
+            setChatSizes(nextSizes);
+            setLayoutKey((key) => key + 1);
+        };
+        hydrate();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const handleLayout = useCallback((sizes: number[]) => {
+        if (!Array.isArray(sizes) || sizes.length < 2) return;
+        const normalized = normalizeChatSizes(sizes[0]);
+        setChatSizes(normalized);
+        void saveLayoutBorders([
+            { border_id: LayoutBorderId.ChatSidebar, axis: 'x', position: normalized[0] },
+        ]);
+    }, []);
+
     return (
         <McpProvider>
             <ModelSelectionProvider>
                 <SystemInstructionsProvider>
                     <ConversationContextProvider>
                         <ChatProvider>
-                            <ResizablePanelGroup direction="horizontal" className="h-full w-full">
-                                <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
+                            <ResizablePanelGroup
+                                key={layoutKey}
+                                direction="horizontal"
+                                className="h-full w-full"
+                                onLayout={handleLayout}
+                            >
+                                <ResizablePanel defaultSize={chatSizes[0]} minSize={15} maxSize={30}>
                                     <ChatSidebar />
                                 </ResizablePanel>
                                 <ResizableHandle withHandle />
-                                <ResizablePanel>
+                                <ResizablePanel defaultSize={chatSizes[1]}>
                                     <ChatPane />
                                 </ResizablePanel>
                             </ResizablePanelGroup>

--- a/src/components/chat/ChatPane.tsx
+++ b/src/components/chat/ChatPane.tsx
@@ -23,7 +23,10 @@ const ChatPane = () => {
         updateMessage,
         selectBranch,
         updateThreadTitle,
-        messages: allMessages // get all messages for parent lookup
+        messages: allMessages, // get all messages for parent lookup
+        drafts,
+        updateDraft,
+        clearDraft,
     } = useChatContext();
 
     const [input, setInput] = useState('');
@@ -41,6 +44,15 @@ const ChatPane = () => {
     const activeThread = activeThreadId ? getThread(activeThreadId) : null;
     const selectedLeafId = activeThread?.leafMessageId || activeThread?.selectedRootChild || null;
     const messages = getMessageChain(selectedLeafId);
+
+    useEffect(() => {
+        if (!activeThreadId) {
+            setInput('');
+            return;
+        }
+        const draftValue = drafts[activeThreadId] ?? '';
+        setInput(draftValue);
+    }, [activeThreadId, drafts]);
 
     useEffect(() => {
         // Scroll to bottom when new messages are added
@@ -320,6 +332,9 @@ const ChatPane = () => {
 
         const userInput = input;
         setInput('');
+        if (currentThreadId) {
+            clearDraft(currentThreadId);
+        }
 
         const currentChain = getMessageChain(activeThread?.leafMessageId || null);
         const parentId = currentChain.length > 0 ? currentChain[currentChain.length - 1].id : null;
@@ -441,7 +456,13 @@ const ChatPane = () => {
                 <form onSubmit={handleSubmit} className="flex items-center gap-2">
                     <Input
                         value={input}
-                        onChange={(e) => setInput(e.target.value)}
+                        onChange={(e) => {
+                            const next = e.target.value;
+                            setInput(next);
+                            if (activeThreadId) {
+                                updateDraft(activeThreadId, next);
+                            }
+                        }}
                         placeholder="Ask anything..."
                         disabled={isLoading}
                         className="flex-1"

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,37 +1,43 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useChatContext } from '@/hooks/useChat';
 import { Button } from '../ui/button';
-import { PlusCircle } from 'lucide-react';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '@/lib/utils';
 
 const ChatSidebar = () => {
     const { threads, activeThreadId, setActiveThreadId, createThread } = useChatContext();
 
+    const orderedThreads = useMemo(
+        () =>
+            [...threads].sort((a, b) => {
+                const aTime = a.updatedAt.getTime();
+                const bTime = b.updatedAt.getTime();
+                return bTime - aTime;
+            }),
+        [threads]
+    );
+
     return (
         <div className="flex h-full flex-col bg-card p-2 text-card-foreground">
             <div className="p-2">
-                <Button onClick={createThread} className="w-full">
-                    <PlusCircle className="mr-2 h-4 w-4" />
-                    New Chat
+                <Button onClick={createThread} className="w-full justify-center text-center">
+                    <span className="w-full text-center">New Chat</span>
                 </Button>
             </div>
             <ScrollArea className="flex-1">
                 <div className="flex flex-col gap-2 p-2">
-                    {threads
-                        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-                        .map((thread) => (
-                            <div
-                                key={thread.id}
-                                onClick={() => setActiveThreadId(thread.id)}
-                                className={cn(
-                                    'cursor-pointer rounded-md p-2 text-sm hover:bg-muted',
-                                    activeThreadId === thread.id && 'bg-primary text-primary-foreground hover:bg-primary/90'
-                                )}
-                            >
-                                <p className="truncate">{thread.title}</p>
-                            </div>
-                        ))}
+                    {orderedThreads.map((thread) => (
+                        <div
+                            key={thread.id}
+                            onClick={() => setActiveThreadId(thread.id)}
+                            className={cn(
+                                'cursor-pointer rounded-md p-2 text-sm hover:bg-muted',
+                                activeThreadId === thread.id && 'bg-primary text-primary-foreground hover:bg-primary/90'
+                            )}
+                        >
+                            <p className="truncate">{thread.title}</p>
+                        </div>
+                    ))}
                 </div>
             </ScrollArea>
         </div>

--- a/src/components/nodes/GoalNode.tsx
+++ b/src/components/nodes/GoalNode.tsx
@@ -11,6 +11,7 @@ interface GoalNodeData {
   onDelete?: () => void;
   onComplete?: () => void;
   onMeasure?: (width: number, height: number) => void;
+  highlighted?: boolean;
 }
 
 export default function GoalNode({ data }: { data: GoalNodeData }) {
@@ -49,7 +50,8 @@ export default function GoalNode({ data }: { data: GoalNodeData }) {
           <div className={cn(
             "rounded-full w-32 h-32 flex items-center justify-center border-4 border-node-goal/20 shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-500",
             (data.status === 'completed') ? "bg-green-500" : "bg-node-goal",
-            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60"
+            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60",
+            data.highlighted && "ring-4 ring-primary/60 shadow-[0_0_0_6px_rgba(59,130,246,0.35)]"
           )}>
             <div className="text-center relative">
               <Target className="w-6 h-6 text-white mb-2 mx-auto" />

--- a/src/components/nodes/MilestoneNode.tsx
+++ b/src/components/nodes/MilestoneNode.tsx
@@ -11,6 +11,7 @@ interface MilestoneNodeData {
   onDelete?: () => void;
   onComplete?: () => void;
   onMeasure?: (width: number, height: number) => void;
+  highlighted?: boolean;
 }
 
 export default function MilestoneNode({ data }: { data: MilestoneNodeData }) {
@@ -49,7 +50,8 @@ export default function MilestoneNode({ data }: { data: MilestoneNodeData }) {
           <div className={cn(
             "rounded-lg p-4 border-2 border-node-milestone/20 shadow-lg min-w-[180px] hover:shadow-xl hover:scale-105 transition-all duration-500",
             (data.status === 'completed') ? "bg-green-500" : "bg-node-milestone",
-            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60"
+            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60",
+            data.highlighted && "ring-4 ring-primary/60 shadow-[0_0_0_6px_rgba(59,130,246,0.35)]"
           )}>
             <div className="flex items-center gap-3">
               <Flag className="w-5 h-5 text-white" />

--- a/src/components/nodes/ObjectiveNode.tsx
+++ b/src/components/nodes/ObjectiveNode.tsx
@@ -12,6 +12,7 @@ interface ObjectiveNodeData {
   onDelete?: () => void;
   onComplete?: () => void;
   onMeasure?: (width: number, height: number) => void;
+  highlighted?: boolean;
 }
 
 const statusIcons = {
@@ -73,7 +74,8 @@ export default function ObjectiveNode({ data }: { data: ObjectiveNodeData }) {
               "rounded-lg border-2 border-blue-400 shadow-lg transition-all duration-500",
               "min-w-[200px] max-w-[300px]",
               isCompleted ? "bg-green-500" : "bg-blue-800",
-              isInProgress && "animate-gentle-pulse border-primary/60"
+              isInProgress && "animate-gentle-pulse border-primary/60",
+              data.highlighted && "ring-4 ring-primary/60 shadow-[0_0_0_6px_rgba(37,99,235,0.35)]"
             )}
           >
             {/* Header */}

--- a/src/components/nodes/StartNode.tsx
+++ b/src/components/nodes/StartNode.tsx
@@ -5,12 +5,13 @@ import { cn } from '@/lib/utils';
 import { useEffect, useRef } from 'react';
 
 interface StartNodeData {
-  label: string; 
+  label: string;
   isActive?: boolean;
   status?: string;
   onDelete?: () => void;
   onComplete?: () => void;
   onMeasure?: (width: number, height: number) => void;
+  highlighted?: boolean;
 }
 
 export default function StartNode({ data }: { data: StartNodeData }) {
@@ -43,7 +44,8 @@ export default function StartNode({ data }: { data: StartNodeData }) {
           <div className={cn(
             "rounded-full w-32 h-32 flex items-center justify-center border-4 border-node-start/20 shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-500",
             (data.status === 'completed') ? "bg-green-500" : "bg-node-start",
-            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60"
+            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60",
+            data.highlighted && "ring-4 ring-primary/60 shadow-[0_0_0_6px_rgba(59,130,246,0.35)]"
           )}>
             <div className="text-center relative">
               <Play className="w-6 h-6 text-white mb-2 mx-auto" />

--- a/src/components/nodes/ValidationNode.tsx
+++ b/src/components/nodes/ValidationNode.tsx
@@ -11,6 +11,7 @@ interface ValidationNodeData {
   onDelete?: () => void;
   onComplete?: () => void;
   onMeasure?: (width: number, height: number) => void;
+  highlighted?: boolean;
 }
 
 export default function ValidationNode({ data }: { data: ValidationNodeData }) {
@@ -49,7 +50,8 @@ export default function ValidationNode({ data }: { data: ValidationNodeData }) {
           <div className={cn(
             "rounded-lg p-4 border-2 border-node-validation/20 shadow-lg min-w-[180px] hover:shadow-xl hover:scale-105 transition-all duration-500",
             (data.status === 'completed') ? "bg-green-500" : "bg-node-validation",
-            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60"
+            (data.status === 'in-progress') && "animate-gentle-pulse border-primary/60",
+            data.highlighted && "ring-4 ring-primary/60 shadow-[0_0_0_6px_rgba(59,130,246,0.35)]"
           )}>
             <div className="flex items-center gap-3">
               <CheckSquare className="w-5 h-5 text-white" />

--- a/src/hooks/chatProvider.tsx
+++ b/src/hooks/chatProvider.tsx
@@ -1,228 +1,688 @@
-import { ReactNode, useState, useEffect, useCallback } from 'react';
+import { ReactNode, useState, useEffect, useCallback, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
     ChatContext,
     Message,
     ChatThread,
-    MessageStore,
     ChatContextValue,
+    ChatThreadMetadata,
 } from './chatProviderContext';
+import { supabase } from '@/integrations/supabase/client';
+import type { TablesInsert } from '@/integrations/supabase/types';
 
 const THREADS_STORAGE_KEY = 'chat_threads';
 const MESSAGES_STORAGE_KEY = 'chat_messages';
+const DRAFTS_STORAGE_KEY = 'chat_drafts';
+const PENDING_OPS_STORAGE_KEY = 'chat_pending_ops_v1';
+
+type PendingOperation =
+    | { type: 'upsert_thread'; payload: TablesInsert<'chat_threads'> }
+    | { type: 'upsert_message'; payload: TablesInsert<'chat_messages'> }
+    | { type: 'upsert_draft'; payload: TablesInsert<'chat_drafts'> }
+    | { type: 'delete_draft'; payload: { thread_id: string } };
+
+type MessageWithThread = Message & { threadId: string };
+
+type MessageRecord = Record<string, MessageWithThread>;
+
+type DraftRecord = Record<string, string>;
+
+const toISO = (value: Date | undefined | null): string | null => {
+    if (!value) return null;
+    try {
+        return value.toISOString();
+    } catch (error) {
+        return null;
+    }
+};
+
+const parseDate = (value: string | null | undefined, fallback: Date): Date => {
+    if (!value) return fallback;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+};
+
+const normalizeThreadFromStorage = (thread: any): ChatThread => {
+    const created = thread?.createdAt ? new Date(thread.createdAt) : new Date();
+    const updated = thread?.updatedAt ? new Date(thread.updatedAt) : created;
+    const rootChildren = Array.isArray(thread?.rootChildren) ? thread.rootChildren : [];
+    return {
+        id: thread?.id ?? uuidv4(),
+        title: thread?.title ?? 'New Chat',
+        createdAt: created,
+        updatedAt: updated,
+        leafMessageId: thread?.leafMessageId ?? null,
+        rootChildren,
+        selectedRootChild: thread?.selectedRootChild ?? (rootChildren.length > 0 ? rootChildren[rootChildren.length - 1] : undefined),
+        selectedChildByMessageId: thread?.selectedChildByMessageId ?? {},
+    };
+};
+
+const normalizeMessageFromStorage = (id: string, message: any): MessageWithThread => {
+    const created = message?.createdAt ? new Date(message.createdAt) : undefined;
+    const updated = message?.updatedAt ? new Date(message.updatedAt) : created;
+    return {
+        id,
+        threadId: message?.threadId ?? '',
+        parentId: message?.parentId ?? null,
+        role: message?.role ?? 'user',
+        content: message?.content ?? '',
+        thinking: message?.thinking ?? undefined,
+        children: Array.isArray(message?.children) ? [...message.children] : [],
+        toolCalls: Array.isArray(message?.toolCalls) ? [...message.toolCalls] : [],
+        createdAt: created,
+        updatedAt: updated,
+    };
+};
+
+const loadStoredThreads = (): ChatThread[] => {
+    try {
+        const raw = localStorage.getItem(THREADS_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.map(normalizeThreadFromStorage);
+    } catch (error) {
+        console.error('Failed to parse threads from localStorage', error);
+        return [];
+    }
+};
+
+const loadStoredMessages = (): MessageRecord => {
+    try {
+        const raw = localStorage.getItem(MESSAGES_STORAGE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) return {};
+        const entries = Object.entries(parsed) as Array<[string, any]>;
+        const result: MessageRecord = {};
+        for (const [id, value] of entries) {
+            result[id] = normalizeMessageFromStorage(id, value);
+        }
+        return result;
+    } catch (error) {
+        console.error('Failed to parse messages from localStorage', error);
+        return {};
+    }
+};
+
+const loadStoredDrafts = (): DraftRecord => {
+    try {
+        const raw = localStorage.getItem(DRAFTS_STORAGE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) return {};
+        return parsed as DraftRecord;
+    } catch (error) {
+        console.error('Failed to parse drafts from localStorage', error);
+        return {};
+    }
+};
+
+const saveStoredThreads = (threads: ChatThread[]) => {
+    try {
+        const serialized = threads.map((thread) => ({
+            ...thread,
+            createdAt: thread.createdAt.toISOString(),
+            updatedAt: thread.updatedAt.toISOString(),
+        }));
+        localStorage.setItem(THREADS_STORAGE_KEY, JSON.stringify(serialized));
+    } catch (error) {
+        console.error('Failed to save threads to localStorage', error);
+    }
+};
+
+const saveStoredMessages = (messages: MessageRecord) => {
+    try {
+        const serialized: Record<string, any> = {};
+        Object.entries(messages).forEach(([id, msg]) => {
+            serialized[id] = {
+                ...msg,
+                createdAt: toISO(msg.createdAt),
+                updatedAt: toISO(msg.updatedAt),
+            };
+        });
+        localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(serialized));
+    } catch (error) {
+        console.error('Failed to save messages to localStorage', error);
+    }
+};
+
+const saveStoredDrafts = (drafts: DraftRecord) => {
+    try {
+        localStorage.setItem(DRAFTS_STORAGE_KEY, JSON.stringify(drafts));
+    } catch (error) {
+        console.error('Failed to save drafts to localStorage', error);
+    }
+};
+
+const loadPendingOperations = (): PendingOperation[] => {
+    try {
+        const raw = localStorage.getItem(PENDING_OPS_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed as PendingOperation[];
+    } catch (error) {
+        console.error('Failed to parse pending chat operations', error);
+        return [];
+    }
+};
+
+const savePendingOperations = (operations: PendingOperation[]) => {
+    try {
+        if (!operations.length) {
+            localStorage.removeItem(PENDING_OPS_STORAGE_KEY);
+        } else {
+            localStorage.setItem(PENDING_OPS_STORAGE_KEY, JSON.stringify(operations));
+        }
+    } catch (error) {
+        console.error('Failed to persist pending chat operations', error);
+    }
+};
+
+const ensureThreadMetadata = (thread: ChatThread): ChatThreadMetadata => ({
+    leafMessageId: thread.leafMessageId ?? null,
+    rootChildren: Array.isArray(thread.rootChildren) ? thread.rootChildren : [],
+    selectedChildByMessageId: thread.selectedChildByMessageId ?? {},
+    selectedRootChild: thread.selectedRootChild,
+});
+
+const toThreadRow = (thread: ChatThread): TablesInsert<'chat_threads'> => ({
+    id: thread.id,
+    title: thread.title,
+    metadata: ensureThreadMetadata(thread),
+    created_at: thread.createdAt.toISOString(),
+    updated_at: thread.updatedAt.toISOString(),
+});
+
+const toMessageRow = (message: MessageWithThread): TablesInsert<'chat_messages'> => ({
+    id: message.id,
+    thread_id: message.threadId,
+    parent_id: message.parentId,
+    role: message.role,
+    content: message.content,
+    thinking: message.thinking ?? null,
+    tool_calls: message.toolCalls ?? null,
+    created_at: message.createdAt ? message.createdAt.toISOString() : null,
+    updated_at: message.updatedAt ? message.updatedAt.toISOString() : new Date().toISOString(),
+});
+
+const toDraftRow = (threadId: string, draftText: string): TablesInsert<'chat_drafts'> => ({
+    thread_id: threadId,
+    draft_text: draftText,
+    updated_at: new Date().toISOString(),
+});
+
+const assignThreadIdsFromRoots = (threads: ChatThread[], messages: MessageRecord) => {
+    const visited = new Set<string>();
+    const visit = (messageId: string, threadId: string) => {
+        if (visited.has(messageId)) return;
+        visited.add(messageId);
+        const message = messages[messageId];
+        if (!message) return;
+        message.threadId = threadId;
+        if (!Array.isArray(message.children)) {
+            message.children = [];
+        }
+        message.children.forEach((childId) => visit(childId, threadId));
+    };
+
+    threads.forEach((thread) => {
+        thread.rootChildren.forEach((childId) => visit(childId, thread.id));
+    });
+};
+
+const buildMessageStore = (messages: MessageWithThread[]): MessageRecord => {
+    const store: MessageRecord = {};
+    messages.forEach((msg) => {
+        store[msg.id] = {
+            ...msg,
+            children: [],
+        };
+    });
+    messages.forEach((msg) => {
+        if (msg.parentId && store[msg.parentId]) {
+            store[msg.parentId].children.push(msg.id);
+        }
+    });
+    return store;
+};
+
+const mergeMessages = (primary: MessageRecord, secondary: MessageRecord): MessageRecord => {
+    const merged: MessageRecord = { ...primary };
+    Object.entries(secondary).forEach(([id, message]) => {
+        if (!merged[id]) {
+            merged[id] = { ...message, children: [...message.children] };
+        }
+    });
+
+    // Rebuild children to ensure consistency
+    Object.values(merged).forEach((message) => {
+        message.children = [];
+    });
+    Object.values(merged).forEach((message) => {
+        if (message.parentId && merged[message.parentId]) {
+            merged[message.parentId].children.push(message.id);
+        }
+    });
+    return merged;
+};
 
 export const ChatProvider = ({ children }: { children: ReactNode }) => {
-    const [threads, setThreads] = useState<ChatThread[]>(() => {
-        try {
-            const storedThreads = localStorage.getItem(THREADS_STORAGE_KEY);
-            if (!storedThreads) return [];
-            const parsed: ChatThread[] = JSON.parse(storedThreads);
-            return parsed.map((thread) => {
-                const rootChildren = thread.rootChildren || [];
-                return {
-                    ...thread,
-                    createdAt: thread.createdAt ? new Date(thread.createdAt) : new Date(),
-                    selectedChildByMessageId: thread.selectedChildByMessageId || {},
-                    rootChildren,
-                    selectedRootChild: thread.selectedRootChild ?? rootChildren[rootChildren.length - 1],
-                };
-            });
-        } catch (e) {
-            console.error("Failed to parse threads from localStorage", e);
-            return [];
-        }
-    });
-
-    const [messages, setMessages] = useState<MessageStore>(() => {
-        try {
-            const storedMessages = localStorage.getItem(MESSAGES_STORAGE_KEY);
-            if (!storedMessages) return {};
-            const parsed: MessageStore = JSON.parse(storedMessages);
-            Object.keys(parsed).forEach((id) => {
-                parsed[id].children = parsed[id].children || [];
-                parsed[id].toolCalls = parsed[id].toolCalls || [];
-            });
-            return parsed;
-        } catch (e) {
-            console.error("Failed to parse messages from localStorage", e);
-            return {};
-        }
-    });
-
+    const [threads, setThreads] = useState<ChatThread[]>([]);
+    const [messages, setMessages] = useState<MessageRecord>({});
+    const [drafts, setDrafts] = useState<DraftRecord>({});
     const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+    const pendingOperationsRef = useRef<PendingOperation[]>(loadPendingOperations());
+    const flushInFlightRef = useRef<Promise<void> | null>(null);
+    const initializedRef = useRef(false);
 
-    // Save to localStorage whenever threads or messages change
-    useEffect(() => {
-        try {
-            localStorage.setItem(THREADS_STORAGE_KEY, JSON.stringify(threads));
-        } catch (e) {
-            console.error("Failed to save threads to localStorage", e);
+    const applyOperation = useCallback(async (operation: PendingOperation) => {
+        switch (operation.type) {
+            case 'upsert_thread': {
+                const { error } = await supabase.from('chat_threads').upsert(operation.payload);
+                if (error) throw error;
+                return;
+            }
+            case 'upsert_message': {
+                const { error } = await supabase.from('chat_messages').upsert(operation.payload);
+                if (error) throw error;
+                return;
+            }
+            case 'upsert_draft': {
+                const { error } = await supabase.from('chat_drafts').upsert(operation.payload);
+                if (error) throw error;
+                return;
+            }
+            case 'delete_draft': {
+                const { error } = await supabase.from('chat_drafts').delete().eq('thread_id', operation.payload.thread_id);
+                if (error) throw error;
+                return;
+            }
+            default:
+                return;
         }
+    }, []);
+
+    const flushPendingOperations = useCallback(async () => {
+        if (flushInFlightRef.current) {
+            await flushInFlightRef.current;
+            return;
+        }
+        const run = async () => {
+            while (pendingOperationsRef.current.length > 0) {
+                const operation = pendingOperationsRef.current[0];
+                try {
+                    await applyOperation(operation);
+                    pendingOperationsRef.current = pendingOperationsRef.current.slice(1);
+                    savePendingOperations(pendingOperationsRef.current);
+                } catch (error) {
+                    console.warn('[ChatProvider] Failed to flush pending operation, will retry later', error);
+                    break;
+                }
+            }
+        };
+        flushInFlightRef.current = run();
+        try {
+            await flushInFlightRef.current;
+        } finally {
+            flushInFlightRef.current = null;
+        }
+    }, [applyOperation]);
+
+    const enqueueOperation = useCallback((operation: PendingOperation) => {
+        pendingOperationsRef.current = [...pendingOperationsRef.current, operation];
+        savePendingOperations(pendingOperationsRef.current);
+    }, []);
+
+    const attemptOperation = useCallback(
+        async (operation: PendingOperation) => {
+            try {
+                await applyOperation(operation);
+                await flushPendingOperations();
+            } catch (error) {
+                console.warn('[ChatProvider] Queueing operation due to error', error);
+                enqueueOperation(operation);
+            }
+        },
+        [applyOperation, enqueueOperation, flushPendingOperations]
+    );
+
+    useEffect(() => {
+        const localThreads = loadStoredThreads();
+        const localMessages = loadStoredMessages();
+        const localDrafts = loadStoredDrafts();
+
+        assignThreadIdsFromRoots(localThreads, localMessages);
+        setThreads(localThreads);
+        setMessages(localMessages);
+        setDrafts(localDrafts);
+
+        const fetchRemote = async () => {
+            try {
+                const [threadsRes, messagesRes, draftsRes] = await Promise.all([
+                    supabase.from('chat_threads').select('*'),
+                    supabase.from('chat_messages').select('*'),
+                    supabase.from('chat_drafts').select('*'),
+                ]);
+
+                if (threadsRes.error) throw threadsRes.error;
+                if (messagesRes.error) throw messagesRes.error;
+                if (draftsRes.error) throw draftsRes.error;
+
+                const remoteThreads = (threadsRes.data || []).map((row) => ({
+                    id: row.id,
+                    title: row.title ?? 'New Chat',
+                    createdAt: parseDate(row.created_at, new Date()),
+                    updatedAt: parseDate(row.updated_at, new Date()),
+                    leafMessageId: (row.metadata as ChatThreadMetadata | null)?.leafMessageId ?? null,
+                    rootChildren: (row.metadata as ChatThreadMetadata | null)?.rootChildren ?? [],
+                    selectedChildByMessageId: (row.metadata as ChatThreadMetadata | null)?.selectedChildByMessageId ?? {},
+                    selectedRootChild: (row.metadata as ChatThreadMetadata | null)?.selectedRootChild ?? undefined,
+                } as ChatThread));
+
+                const remoteMessagesArray: MessageWithThread[] = (messagesRes.data || []).map((row) => ({
+                    id: row.id,
+                    threadId: row.thread_id,
+                    parentId: row.parent_id,
+                    role: row.role as Message['role'],
+                    content: row.content ?? '',
+                    thinking: row.thinking ?? undefined,
+                    toolCalls: Array.isArray(row.tool_calls) ? row.tool_calls : undefined,
+                    children: [],
+                    createdAt: row.created_at ? new Date(row.created_at) : undefined,
+                    updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
+                }));
+
+                const remoteMessages = buildMessageStore(remoteMessagesArray);
+                const remoteDrafts: DraftRecord = {};
+                (draftsRes.data || []).forEach((row) => {
+                    remoteDrafts[row.thread_id] = row.draft_text ?? '';
+                });
+
+                const remoteThreadIds = new Set(remoteThreads.map((thread) => thread.id));
+                const remoteMessageIds = new Set(Object.keys(remoteMessages));
+
+                const missingThreads = localThreads.filter((thread) => !remoteThreadIds.has(thread.id));
+                const missingMessages = Object.values(localMessages).filter((message) => !remoteMessageIds.has(message.id));
+                const missingDraftEntries = Object.entries(localDrafts).filter(([threadId]) => remoteDrafts[threadId] === undefined);
+
+                await Promise.all([
+                    ...missingThreads.map((thread) => attemptOperation({ type: 'upsert_thread', payload: toThreadRow(thread) })),
+                    ...missingMessages.map((message) => attemptOperation({ type: 'upsert_message', payload: toMessageRow(message) })),
+                    ...missingDraftEntries.map(([threadId, draftText]) =>
+                        attemptOperation({ type: 'upsert_draft', payload: toDraftRow(threadId, draftText) })
+                    ),
+                ]);
+
+                const mergedThreadsMap = new Map<string, ChatThread>();
+                remoteThreads.forEach((thread) => mergedThreadsMap.set(thread.id, thread));
+                missingThreads.forEach((thread) => mergedThreadsMap.set(thread.id, thread));
+                const mergedThreads = Array.from(mergedThreadsMap.values()).sort(
+                    (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()
+                );
+
+                const mergedMessages = mergeMessages(remoteMessages, buildMessageStore(missingMessages));
+                assignThreadIdsFromRoots(mergedThreads, mergedMessages);
+
+                const mergedDrafts: DraftRecord = { ...remoteDrafts };
+                missingDraftEntries.forEach(([threadId, draftText]) => {
+                    mergedDrafts[threadId] = draftText;
+                });
+
+                setThreads(mergedThreads);
+                setMessages(mergedMessages);
+                setDrafts(mergedDrafts);
+                initializedRef.current = true;
+            } catch (error) {
+                console.error('[ChatProvider] Failed to load remote chat data', error);
+                initializedRef.current = true;
+            }
+        };
+
+        fetchRemote();
+    }, [attemptOperation]);
+
+    useEffect(() => {
+        const handleOnline = () => {
+            flushPendingOperations();
+        };
+        window.addEventListener('online', handleOnline);
+        return () => window.removeEventListener('online', handleOnline);
+    }, [flushPendingOperations]);
+
+    useEffect(() => {
+        if (!initializedRef.current) return;
+        saveStoredThreads(threads);
     }, [threads]);
 
     useEffect(() => {
-        try {
-            localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(messages));
-        } catch (e) {
-            console.error("Failed to save messages to localStorage", e);
-        }
+        if (!initializedRef.current) return;
+        saveStoredMessages(messages);
     }, [messages]);
 
+    useEffect(() => {
+        if (!initializedRef.current) return;
+        saveStoredDrafts(drafts);
+    }, [drafts]);
 
-    const getThread = useCallback((id: string) => threads.find((t) => t.id === id), [threads]);
+    const getThread = useCallback((id: string) => threads.find((thread) => thread.id === id), [threads]);
 
-    const getMessageChain = useCallback((leafId: string | null): Message[] => {
-        if (!leafId) return [];
-        const chain: Message[] = [];
-        let currentId: string | null = leafId;
-        while (currentId) {
-            const message = messages[currentId];
-            if (!message) break;
-            chain.unshift(message);
-            currentId = message.parentId;
-        }
-        return chain;
-    }, [messages]);
+    const getMessageChain = useCallback(
+        (leafId: string | null): Message[] => {
+            if (!leafId) return [];
+            const chain: Message[] = [];
+            let current: string | null = leafId;
+            while (current) {
+                const message = messages[current];
+                if (!message) break;
+                chain.unshift(message);
+                current = message.parentId;
+            }
+            return chain;
+        },
+        [messages]
+    );
 
     const createThread = useCallback(() => {
+        const timestamp = new Date();
         const newThread: ChatThread = {
             id: uuidv4(),
             title: 'New Chat',
+            createdAt: timestamp,
+            updatedAt: timestamp,
             leafMessageId: null,
-            createdAt: new Date(),
-            selectedChildByMessageId: {},
             rootChildren: [],
+            selectedChildByMessageId: {},
+            selectedRootChild: undefined,
         };
         setThreads((prev) => [...prev, newThread]);
         setActiveThreadId(newThread.id);
+        attemptOperation({ type: 'upsert_thread', payload: toThreadRow(newThread) });
         return newThread.id;
-    }, []);
+    }, [attemptOperation]);
 
-    const addMessage = useCallback(
-        (
-            threadId: string,
-            messageData: Omit<Message, 'id' | 'children' | 'toolCalls'>
-        ): Message => {
-            const newId = uuidv4();
-            const newMessage: Message = {
-                ...messageData,
+    const addMessage = useCallback<ChatContextValue['addMessage']>(
+        (threadId, messageData) => {
+            const newId = messageData.id ?? uuidv4();
+            const timestamp = new Date();
+            const newMessage: MessageWithThread = {
                 id: newId,
-                children: [],
+                threadId,
+                parentId: messageData.parentId ?? null,
+                role: messageData.role,
+                content: messageData.content,
+                thinking: messageData.thinking,
                 toolCalls: messageData.toolCalls ? [...messageData.toolCalls] : [],
+                children: [],
+                createdAt: timestamp,
+                updatedAt: timestamp,
             };
 
+            let updatedThread: ChatThread | null = null;
             setMessages((prev) => {
-                const updated = {
-                    ...prev,
-                    [newId]: newMessage,
-                };
-                if (messageData.parentId && prev[messageData.parentId]) {
-                    updated[messageData.parentId] = {
-                        ...prev[messageData.parentId],
-                        children: [...prev[messageData.parentId].children, newId],
+                const next = { ...prev, [newId]: newMessage };
+                if (newMessage.parentId && next[newMessage.parentId]) {
+                    next[newMessage.parentId] = {
+                        ...next[newMessage.parentId],
+                        children: [...new Set([...next[newMessage.parentId].children, newId])],
+                        updatedAt: timestamp,
                     };
                 }
-                return updated;
+                return next;
             });
 
             setThreads((prev) =>
                 prev.map((thread) => {
                     if (thread.id !== threadId) return thread;
-
                     const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
-                    let rootChildren = thread.rootChildren ? [...thread.rootChildren] : [];
+                    let rootChildren = [...thread.rootChildren];
                     let selectedRootChild = thread.selectedRootChild;
 
-                    if (messageData.parentId) {
-                        selectedChildByMessageId[messageData.parentId] = newId;
+                    if (newMessage.parentId) {
+                        selectedChildByMessageId[newMessage.parentId] = newId;
                     } else {
                         rootChildren = [...rootChildren, newId];
                         selectedRootChild = newId;
                     }
 
-                    return {
+                    const updated: ChatThread = {
                         ...thread,
                         title:
-                            thread.title === 'New Chat' && messageData.role === 'user'
-                                ? `${messageData.content.substring(0, 30)}...`
+                            thread.title === 'New Chat' && newMessage.role === 'user'
+                                ? `${newMessage.content.substring(0, 30)}...`
                                 : thread.title,
                         leafMessageId: newId,
                         selectedChildByMessageId,
                         rootChildren,
                         selectedRootChild,
+                        updatedAt: timestamp,
                     };
+                    updatedThread = updated;
+                    return updated;
                 })
             );
+
+            attemptOperation({ type: 'upsert_message', payload: toMessageRow(newMessage) });
+            if (updatedThread) {
+                attemptOperation({ type: 'upsert_thread', payload: toThreadRow(updatedThread) });
+            }
             return newMessage;
         },
-        []
+        [attemptOperation]
     );
 
-    const updateMessage = useCallback((messageId: string, updates: Partial<Message> | ((message: Message) => Partial<Message>)) => {
-        setMessages((prev) => {
-            const current = prev[messageId];
-            if (!current) {
-                console.warn(`[ChatProvider] Attempted to update non-existent message: ${messageId}`);
-                return prev;
-            }
-            const appliedUpdates = typeof updates === 'function' ? updates(current) : updates;
-            const updatedMessages = {
-                ...prev,
-                [messageId]: {
+    const updateMessage = useCallback<ChatContextValue['updateMessage']>(
+        (messageId, updates) => {
+            let nextMessage: MessageWithThread | null = null;
+            const timestamp = new Date();
+            setMessages((prev) => {
+                const current = prev[messageId];
+                if (!current) {
+                    console.warn(`[ChatProvider] Attempted to update missing message ${messageId}`);
+                    return prev;
+                }
+                const applied = typeof updates === 'function' ? updates(current) : updates;
+                nextMessage = {
                     ...current,
-                    ...appliedUpdates,
-                },
-            };
-            return updatedMessages;
-        });
-    }, []);
+                    ...applied,
+                    updatedAt: timestamp,
+                };
+                return {
+                    ...prev,
+                    [messageId]: nextMessage!,
+                };
+            });
+            if (nextMessage) {
+                attemptOperation({ type: 'upsert_message', payload: toMessageRow(nextMessage) });
+            }
+        },
+        [attemptOperation]
+    );
 
-    const selectBranch = useCallback((threadId: string | null, parentId: string | null, childId: string) => {
-        if (!threadId) return;
+    const selectBranch = useCallback<ChatContextValue['selectBranch']>(
+        (threadId, parentId, childId) => {
+            if (!threadId) return;
+            let updatedThread: ChatThread | null = null;
+            const timestamp = new Date();
+            setThreads((prev) =>
+                prev.map((thread) => {
+                    if (thread.id !== threadId) return thread;
+                    const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
+                    let selectedRootChild = thread.selectedRootChild;
+
+                    if (parentId) {
+                        selectedChildByMessageId[parentId] = childId;
+                    } else {
+                        selectedRootChild = childId;
+                    }
+
+                    let nextLeaf: string | null | undefined = childId;
+                    const visited = new Set<string>();
+                    while (nextLeaf && !visited.has(nextLeaf)) {
+                        visited.add(nextLeaf);
+                        const message = messages[nextLeaf];
+                        if (!message || message.children.length === 0) break;
+                        const selectedChild = selectedChildByMessageId[nextLeaf] ?? message.children[message.children.length - 1];
+                        selectedChildByMessageId[nextLeaf] = selectedChild;
+                        nextLeaf = selectedChild;
+                    }
+
+                    updatedThread = {
+                        ...thread,
+                        selectedChildByMessageId,
+                        selectedRootChild,
+                        leafMessageId: nextLeaf || childId,
+                        updatedAt: timestamp,
+                    };
+                    return updatedThread;
+                })
+            );
+            if (updatedThread) {
+                attemptOperation({ type: 'upsert_thread', payload: toThreadRow(updatedThread) });
+            }
+        },
+        [attemptOperation, messages]
+    );
+
+    const updateThreadTitle = useCallback<ChatContextValue['updateThreadTitle']>((threadId, title) => {
+        let updatedThread: ChatThread | null = null;
+        const timestamp = new Date();
         setThreads((prev) =>
             prev.map((thread) => {
                 if (thread.id !== threadId) return thread;
-
-                const selectedChildByMessageId = { ...thread.selectedChildByMessageId };
-                let selectedRootChild = thread.selectedRootChild;
-
-                if (parentId) {
-                    selectedChildByMessageId[parentId] = childId;
-                } else {
-                    selectedRootChild = childId;
-                }
-
-                let nextLeaf: string | undefined | null = childId;
-                const visited = new Set<string>();
-
-                while (nextLeaf && !visited.has(nextLeaf)) {
-                    visited.add(nextLeaf);
-                    const message = messages[nextLeaf];
-                    if (!message || message.children.length === 0) break;
-                    const selectedChild = selectedChildByMessageId[nextLeaf] ?? message.children[message.children.length - 1];
-                    selectedChildByMessageId[nextLeaf] = selectedChild;
-                    nextLeaf = selectedChild;
-                }
-
-                return {
+                updatedThread = {
                     ...thread,
-                    selectedChildByMessageId,
-                    selectedRootChild,
-                    leafMessageId: nextLeaf || childId,
+                    title,
+                    updatedAt: timestamp,
                 };
+                return updatedThread;
             })
         );
-    }, [messages]);
+        if (updatedThread) {
+            attemptOperation({ type: 'upsert_thread', payload: toThreadRow(updatedThread) });
+        }
+    }, [attemptOperation]);
 
-    const updateThreadTitle = useCallback((threadId: string, title: string) => {
-        setThreads((prev) =>
-            prev.map((thread) => (thread.id === threadId ? { ...thread, title } : thread))
-        );
-    }, []);
+    const updateDraft = useCallback<ChatContextValue['updateDraft']>((threadId, draftText) => {
+        setDrafts((prev) => ({ ...prev, [threadId]: draftText }));
+        attemptOperation({ type: 'upsert_draft', payload: toDraftRow(threadId, draftText) });
+    }, [attemptOperation]);
+
+    const clearDraft = useCallback<ChatContextValue['clearDraft']>((threadId) => {
+        setDrafts((prev) => {
+            const next = { ...prev };
+            delete next[threadId];
+            return next;
+        });
+        attemptOperation({ type: 'delete_draft', payload: { thread_id: threadId } });
+    }, [attemptOperation]);
 
     const value: ChatContextValue = {
         threads,
         messages,
+        drafts,
         activeThreadId,
         setActiveThreadId,
         getThread,
@@ -232,7 +692,10 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         updateMessage,
         selectBranch,
         updateThreadTitle,
+        updateDraft,
+        clearDraft,
     };
 
     return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
 };
+

--- a/src/hooks/chatProviderContext.ts
+++ b/src/hooks/chatProviderContext.ts
@@ -11,39 +11,55 @@ export interface ToolCallState {
 
 export interface Message {
     id: string;
-    parentId: string | null; 
-    role: 'user' | 'assistant';
+    threadId: string;
+    parentId: string | null;
+    role: 'system' | 'user' | 'assistant' | 'tool';
     content: string;
     thinking?: string;
     children: string[];
     toolCalls?: ToolCallState[];
+    createdAt?: Date;
+    updatedAt?: Date;
 }
 
 export type MessageStore = Record<string, Message>;
 
-export interface ChatThread {
+export interface ChatThreadMetadata {
+    leafMessageId: string | null;
+    rootChildren: string[];
+    selectedChildByMessageId: Record<string, string>;
+    selectedRootChild?: string;
+}
+
+export interface ChatThread extends ChatThreadMetadata {
     id: string;
     title: string;
-    leafMessageId: string | null;
     createdAt: Date;
-    selectedChildByMessageId: Record<string, string>;
-    rootChildren: string[];
-    selectedRootChild?: string;
+    updatedAt: Date;
 }
 
 export interface ChatContextValue {
     threads: ChatThread[];
     messages: MessageStore;
+    drafts: Record<string, string>;
     activeThreadId: string | null;
-    
+
     setActiveThreadId: (id: string | null) => void;
     getThread: (id: string) => ChatThread | undefined;
     createThread: () => string;
-    addMessage: (threadId: string, message: Omit<Message, 'id' | 'children'>) => Message;
+    addMessage: (
+        threadId: string,
+        message: Omit<Message, 'id' | 'children' | 'threadId'> & { id?: string }
+    ) => Message;
     getMessageChain: (leafId: string | null) => Message[];
-    updateMessage: (messageId: string, updates: Partial<Message>) => void;
+    updateMessage: (
+        messageId: string,
+        updates: Partial<Message> | ((message: Message) => Partial<Message>)
+    ) => void;
     selectBranch: (threadId: string | null, parentId: string | null, childId: string) => void;
     updateThreadTitle: (threadId: string, title: string) => void;
+    updateDraft: (threadId: string, draftText: string) => void;
+    clearDraft: (threadId: string) => void;
 }
 
 export const ChatContext = createContext<ChatContextValue | undefined>(undefined);

--- a/src/hooks/useGraphData.ts
+++ b/src/hooks/useGraphData.ts
@@ -155,12 +155,12 @@ export function useGraphData() {
       // Fetch the single graph document
       const { data: docRow, error: docError } = await (supabase as any)
         .from('graph_documents')
-        .select('data')
+        .select('document')
         .eq('id', 'main')
         .maybeSingle();
 
       if (docError) throw docError;
-      const data = (docRow?.data as any) || {};
+      const data = (docRow?.document as any) || {};
       setDocData(data);
 
       console.log('[Graph] Initial fetch complete. Active graph:', activeGraphId);
@@ -335,7 +335,7 @@ export function useGraphData() {
 
       const { error } = await (supabase as any)
         .from('graph_documents')
-        .update({ data: nextDoc })
+        .update({ document: nextDoc })
         .eq('id', 'main');
       if (error) throw error;
 
@@ -413,7 +413,7 @@ export function useGraphData() {
 
       const { error } = await (supabase as any)
         .from('graph_documents')
-        .update({ data: nextDoc })
+        .update({ document: nextDoc })
         .eq('id', 'main');
       if (error) throw error;
 
@@ -442,7 +442,7 @@ export function useGraphData() {
 
       const { error } = await (supabase as any)
         .from('graph_documents')
-        .update({ data: nextDoc })
+        .update({ document: nextDoc })
         .eq('id', 'main');
 
       if (error) throw error;
@@ -599,7 +599,7 @@ export function useGraphData() {
     if (JSON.stringify(newHistory) !== JSON.stringify(docData.historical_progress || {})) {
       const nextDoc = { ...docData, historical_progress: newHistory };
       setDocData(nextDoc);
-      await supabase.from('graph_documents').update({ data: nextDoc }).eq('id', 'main');
+      await supabase.from('graph_documents').update({ document: nextDoc }).eq('id', 'main');
     }
   };
 
@@ -622,7 +622,7 @@ export function useGraphData() {
 
         const { error } = await (supabase as any)
           .from('graph_documents')
-          .update({ data: nextDoc })
+          .update({ document: nextDoc })
           .eq('id', 'main');
         if (error) throw error;
 
@@ -656,7 +656,7 @@ export function useGraphData() {
         try {
           // Skip handling if this client just wrote
           if (localOperationsRef.current.size > 0) return;
-          const next = payload?.new?.data;
+          const next = payload?.new?.document;
           if (next) {
             setDocData(next);
             // buildGraphForActiveId(next, activeGraphId); // useMemo handles this
@@ -716,7 +716,7 @@ export function useGraphData() {
       };
       setDocData(nextDoc);
       setNodeToGraphMap(determineNodeGraphs(nextDoc.nodes));
-      supabase.from('graph_documents').update({ data: nextDoc }).eq('id', 'main').then(({ error }) => {
+      supabase.from('graph_documents').update({ document: nextDoc }).eq('id', 'main').then(({ error }) => {
         if (error) console.error("Error in midnight update:", error);
       });
     }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7,179 +7,168 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "13.0.4"
   }
   public: {
     Tables: {
-      edges: {
-        Row: {
-          animated: boolean | null
-          created_at: string | null
-          id: string
-          source_id: string
-          style: Json | null
-          target_id: string
-          updated_at: string | null
-        }
-        Insert: {
-          animated?: boolean | null
-          created_at?: string | null
-          id: string
-          source_id: string
-          style?: Json | null
-          target_id: string
-          updated_at?: string | null
-        }
-        Update: {
-          animated?: boolean | null
-          created_at?: string | null
-          id?: string
-          source_id?: string
-          style?: Json | null
-          target_id?: string
-          updated_at?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "edges_source_id_fkey"
-            columns: ["source_id"]
-            isOneToOne: false
-            referencedRelation: "nodes"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "edges_target_id_fkey"
-            columns: ["target_id"]
-            isOneToOne: false
-            referencedRelation: "nodes"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       graph_documents: {
         Row: {
-          data: Json
           id: string
+          document: Json
           updated_at: string | null
         }
         Insert: {
-          data: Json
           id?: string
+          document: Json
           updated_at?: string | null
         }
         Update: {
-          data?: Json
           id?: string
+          document?: Json
           updated_at?: string | null
         }
         Relationships: []
       }
-      graph_state: {
+      system_instructions: {
         Row: {
-          active_node_id: string | null
-          created_at: string
-          id: number
-          updated_at: string
-          viewport_x: number | null
-          viewport_y: number | null
-          viewport_zoom: number | null
+          id: string
+          content: string
+          updated_at: string | null
         }
         Insert: {
-          active_node_id?: string | null
-          created_at?: string
-          id?: number
-          updated_at?: string
-          viewport_x?: number | null
-          viewport_y?: number | null
-          viewport_zoom?: number | null
+          id?: string
+          content: string
+          updated_at?: string | null
         }
         Update: {
-          active_node_id?: string | null
-          created_at?: string
-          id?: number
-          updated_at?: string
-          viewport_x?: number | null
-          viewport_y?: number | null
-          viewport_zoom?: number | null
+          id?: string
+          content?: string
+          updated_at?: string | null
         }
         Relationships: []
       }
-      nodes: {
+      chat_threads: {
         Row: {
+          id: string
+          title: string | null
+          metadata: Json | null
           created_at: string | null
-          expanded: boolean | null
-          id: string
-          label: string
-          position_x: number
-          position_y: number
-          status: string | null
-          type: string
           updated_at: string | null
         }
         Insert: {
+          id?: string
+          title?: string | null
+          metadata?: Json | null
           created_at?: string | null
-          expanded?: boolean | null
-          id: string
-          label: string
-          position_x: number
-          position_y: number
-          status?: string | null
-          type: string
           updated_at?: string | null
         }
         Update: {
-          created_at?: string | null
-          expanded?: boolean | null
           id?: string
-          label?: string
-          position_x?: number
-          position_y?: number
-          status?: string | null
-          type?: string
+          title?: string | null
+          metadata?: Json | null
+          created_at?: string | null
           updated_at?: string | null
         }
         Relationships: []
       }
-      sub_objectives: {
+      chat_messages: {
         Row: {
-          created_at: string | null
           id: string
-          label: string
-          node_id: string
-          order_index: number
-          status: string | null
+          thread_id: string
+          parent_id: string | null
+          role: string
+          content: string | null
+          thinking: string | null
+          tool_calls: Json | null
+          created_at: string | null
           updated_at: string | null
         }
         Insert: {
-          created_at?: string | null
           id: string
-          label: string
-          node_id: string
-          order_index: number
-          status?: string | null
+          thread_id: string
+          parent_id?: string | null
+          role: string
+          content?: string | null
+          thinking?: string | null
+          tool_calls?: Json | null
+          created_at?: string | null
           updated_at?: string | null
         }
         Update: {
-          created_at?: string | null
           id?: string
-          label?: string
-          node_id?: string
-          order_index?: number
-          status?: string | null
+          thread_id?: string
+          parent_id?: string | null
+          role?: string
+          content?: string | null
+          thinking?: string | null
+          tool_calls?: Json | null
+          created_at?: string | null
           updated_at?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "sub_objectives_node_id_fkey"
-            columns: ["node_id"]
+            foreignKeyName: "chat_messages_parent_id_fkey"
+            columns: ["parent_id"]
             isOneToOne: false
-            referencedRelation: "nodes"
+            referencedRelation: "chat_messages"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "chat_messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "chat_threads"
+            referencedColumns: ["id"]
+          }
         ]
+      }
+      chat_drafts: {
+        Row: {
+          thread_id: string
+          draft_text: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          thread_id: string
+          draft_text?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          thread_id?: string
+          draft_text?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_drafts_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: true
+            referencedRelation: "chat_threads"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      layout_borders: {
+        Row: {
+          border_id: string
+          axis: "x" | "y"
+          position: number
+          updated_at: string | null
+        }
+        Insert: {
+          border_id: string
+          axis: "x" | "y"
+          position: number
+          updated_at?: string | null
+        }
+        Update: {
+          border_id?: string
+          axis?: "x" | "y"
+          position?: number
+          updated_at?: string | null
+        }
+        Relationships: []
       }
     }
     Views: {

--- a/src/services/layoutPersistence.ts
+++ b/src/services/layoutPersistence.ts
@@ -1,0 +1,55 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type LayoutAxis = 'x' | 'y';
+
+export const LayoutBorderId = {
+    MainVerticalTop: 'main-vertical-top-progress',
+    MainVerticalBottom: 'main-vertical-progress-chat',
+    MainHorizontalGraphTasks: 'main-horizontal-graph-tasks',
+    MainHorizontalTasksCalendar: 'main-horizontal-tasks-calendar',
+    ProgressHorizontal: 'main-progress-progress-stats',
+    ChatSidebar: 'chat-sidebar-divider',
+} as const;
+
+export type LayoutBorderId = (typeof LayoutBorderId)[keyof typeof LayoutBorderId];
+
+export interface LayoutBorderRecord {
+    border_id: LayoutBorderId;
+    axis: LayoutAxis;
+    position: number;
+}
+
+export const loadLayoutBorders = async (): Promise<Record<string, LayoutBorderRecord>> => {
+    try {
+        const { data, error } = await supabase.from('layout_borders').select('border_id, axis, position');
+        if (error) throw error;
+        if (!data) return {};
+        return data.reduce<Record<string, LayoutBorderRecord>>((acc, row) => {
+            acc[row.border_id] = {
+                border_id: row.border_id as LayoutBorderId,
+                axis: row.axis as LayoutAxis,
+                position: Number(row.position),
+            };
+            return acc;
+        }, {});
+    } catch (error) {
+        console.error('[LayoutPersistence] Failed to load layout borders', error);
+        return {};
+    }
+};
+
+export const saveLayoutBorders = async (borders: LayoutBorderRecord[]): Promise<void> => {
+    if (!borders.length) return;
+    const payload = borders.map((border) => ({
+        border_id: border.border_id,
+        axis: border.axis,
+        position: border.position,
+        updated_at: new Date().toISOString(),
+    }));
+    try {
+        const { error } = await supabase.from('layout_borders').upsert(payload);
+        if (error) throw error;
+    } catch (error) {
+        console.error('[LayoutPersistence] Failed to save layout borders', error);
+    }
+};


### PR DESCRIPTION
## Summary
- replace local chat storage with Supabase-backed threads, messages, and drafts plus offline queueing
- persist resizable layout borders to Supabase for the main mosaic and chat sidebar
- enable task and calendar navigation to focus nodes, adjust UI sizing, and shrink graph controls per spec

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: lint errors from existing @typescript-eslint/no-explicit-any rules)*

------
https://chatgpt.com/codex/tasks/task_e_68dd704f29f48323af81780d57e9e18d