### PR TITLE
Add tool intent preflight and refresh chat layout

### DIFF
--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
+import React, { useMemo, useState } from 'react';
 import ChatSidebar from './ChatSidebar';
 import ChatPane from './ChatPane';
 import { ChatProvider } from '@/hooks/chatProvider';
@@ -7,51 +6,21 @@ import { SystemInstructionsProvider } from '@/hooks/systemInstructionProvider';
 import { ModelSelectionProvider } from '@/hooks/modelSelectionProvider';
 import { McpProvider } from '@/hooks/mcpProvider';
 import { ConversationContextProvider } from '@/hooks/conversationContextProvider';
-import { fetchLayoutBorders, persistLayoutBorders } from '@/services/layoutPersistence';
+import { cn } from '@/lib/utils';
+import { Button } from '../ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+const SIDEBAR_WIDTH_PERCENT = 40;
 
 const ChatLayout = () => {
-    const DEFAULT_CHAT_LAYOUT = [20, 80] as const;
-    const [chatLayout, setChatLayout] = useState<number[] | null>(null);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
-    useEffect(() => {
-        let isMounted = true;
-        const loadLayout = async () => {
-            const borders = await fetchLayoutBorders();
-            const position = borders['chat-horizontal-1']?.position;
-            const layout = typeof position === 'number'
-                ? [position, 100 - position]
-                : [...DEFAULT_CHAT_LAYOUT];
-            if (!borders['chat-horizontal-1']) {
-                void persistLayoutBorders([
-                    { borderId: 'chat-horizontal-1', axis: 'x' as const, position: layout[0] },
-                ]);
-            }
-            if (isMounted) {
-                setChatLayout(layout);
-            }
-        };
-        void loadLayout();
-        return () => {
-            isMounted = false;
-        };
-    }, []);
-
-    const handleChatLayoutChange = useCallback((sizes: number[]) => {
-        setChatLayout(sizes);
-        void persistLayoutBorders([
-            { borderId: 'chat-horizontal-1', axis: 'x' as const, position: sizes[0] },
-        ]);
-    }, []);
-
-    if (!chatLayout) {
-        return (
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-                Loading chat layout...
-            </div>
-        );
-    }
-
-    const resolvedChatLayout = chatLayout;
+    const toggleButtonLeft = useMemo(() => {
+        if (isSidebarOpen) {
+            return `calc(${SIDEBAR_WIDTH_PERCENT}% - 16px)`;
+        }
+        return '0px';
+    }, [isSidebarOpen]);
 
     return (
         <McpProvider>
@@ -59,19 +28,38 @@ const ChatLayout = () => {
                 <SystemInstructionsProvider>
                     <ConversationContextProvider>
                         <ChatProvider>
-                            <ResizablePanelGroup
-                                direction="horizontal"
-                                className="h-full w-full"
-                                onLayout={handleChatLayoutChange}
-                            >
-                                <ResizablePanel defaultSize={resolvedChatLayout[0]} minSize={15} maxSize={30}>
-                                    <ChatSidebar />
-                                </ResizablePanel>
-                                <ResizableHandle withHandle />
-                                <ResizablePanel defaultSize={resolvedChatLayout[1]}>
+                            <div className="relative flex h-full w-full overflow-hidden bg-background">
+                                <div
+                                    className="relative h-full transition-[width] duration-300 ease-in-out"
+                                    style={{ width: isSidebarOpen ? `${SIDEBAR_WIDTH_PERCENT}%` : '0%' }}
+                                >
+                                    <div
+                                        className={cn(
+                                            'absolute inset-0 flex h-full flex-col transition-opacity duration-300 ease-in-out',
+                                            isSidebarOpen
+                                                ? 'pointer-events-auto opacity-100'
+                                                : 'pointer-events-none opacity-0'
+                                        )}
+                                    >
+                                        <ChatSidebar />
+                                    </div>
+                                </div>
+                                <div className="flex-1 transition-all duration-300 ease-in-out">
                                     <ChatPane />
-                                </ResizablePanel>
-                            </ResizablePanelGroup>
+                                </div>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="icon"
+                                    className="absolute top-1/2 z-30 -translate-y-1/2 rounded-r-md border border-border bg-card text-card-foreground shadow-md hover:bg-card/90"
+                                    style={{ left: toggleButtonLeft }}
+                                    onClick={() => setIsSidebarOpen((prev) => !prev)}
+                                    aria-label={isSidebarOpen ? 'Collapse chat list' : 'Expand chat list'}
+                                    aria-expanded={isSidebarOpen}
+                                >
+                                    {isSidebarOpen ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                                </Button>
+                            </div>
                         </ChatProvider>
                     </ConversationContextProvider>
                 </SystemInstructionsProvider>

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -3,15 +3,21 @@ import { useChatContext } from '@/hooks/useChat';
 import { Button } from '../ui/button';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '@/lib/utils';
+import { Plus } from 'lucide-react';
 
 const ChatSidebar = () => {
     const { threads, activeThreadId, setActiveThreadId, createThread } = useChatContext();
 
     return (
         <div className="flex h-full flex-col bg-card p-2 text-card-foreground">
-            <div className="p-2">
-                <Button onClick={createThread} className="w-full justify-center">
-                    <span className="text-sm font-medium">New Chat</span>
+            <div className="flex justify-center p-2">
+                <Button
+                    onClick={createThread}
+                    size="icon"
+                    className="h-10 w-10 rounded-full"
+                    aria-label="Start a new chat"
+                >
+                    <Plus className="h-4 w-4" />
                 </Button>
             </div>
             <ScrollArea className="flex-1">

--- a/src/hooks/modelSelectionProviderContext.ts
+++ b/src/hooks/modelSelectionProviderContext.ts
@@ -12,6 +12,8 @@ export interface ModelSelectionContextValue {
     getUsageCount: (modelId: string) => number;
     getUsageScore: (modelId: string) => number;
     usageCounts: Record<string, number>;
+    isToolIntentCheckEnabled: (modelId: string) => boolean;
+    setToolIntentCheckEnabled: (modelId: string, enabled: boolean) => void;
 }
 
 export const ModelSelectionContext = createContext<ModelSelectionContextValue | undefined>(undefined);

--- a/src/services/openRouter.ts
+++ b/src/services/openRouter.ts
@@ -3,6 +3,9 @@
 const OPEN_ROUTER_API_KEY = import.meta.env.VITE_OPENROUTER_API_KEY;
 const API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MODELS_API_URL = "https://openrouter.ai/api/v1/models";
+const TOOL_INTENT_MODEL_ID = 'google/gemini-2.5-pro-flash';
+const TOOL_INTENT_PROMPT =
+    'You are an expert at classifying user intent. The user has access to specialized tools for interacting with a personal knowledge graph. Your only job is to determine if the user\'s query requires one of these specialized tools or if it is a general conversational query. Respond with ONLY the single word TOOL if a specialized tool is needed, or the single word CONVERSATION if it is a general knowledge question, statement, or command.';
 
 export interface ApiToolCall {
     id: string;
@@ -51,6 +54,68 @@ export interface ModelInfo {
     name: string;
     description?: string;
 }
+
+export const getToolIntent = async (userQuery: string): Promise<'TOOL' | 'CONVERSATION'> => {
+    if (!OPEN_ROUTER_API_KEY) {
+        throw new Error("VITE_OPENROUTER_API_KEY is not set in .env file");
+    }
+
+    try {
+        const response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${OPEN_ROUTER_API_KEY}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                model: TOOL_INTENT_MODEL_ID,
+                stream: false,
+                temperature: 0,
+                max_output_tokens: 1,
+                messages: [
+                    { role: 'system', content: TOOL_INTENT_PROMPT },
+                    { role: 'user', content: userQuery },
+                ],
+            }),
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new Error(`Intent classification failed: ${response.status} ${response.statusText} - ${errorBody}`);
+        }
+
+        const data = await response.json();
+        const message = data?.choices?.[0]?.message;
+        let content = '';
+
+        if (typeof message?.content === 'string') {
+            content = message.content;
+        } else if (Array.isArray(message?.content)) {
+            content = message.content
+                .map((segment: unknown) => {
+                    if (typeof segment === 'string') return segment;
+                    if (segment && typeof segment === 'object' && 'text' in segment) {
+                        return (segment as { text?: string }).text ?? '';
+                    }
+                    return '';
+                })
+                .join(' ');
+        }
+
+        const normalized = content.trim().toUpperCase();
+        if (normalized === 'CONVERSATION') {
+            return 'CONVERSATION';
+        }
+        if (normalized === 'TOOL') {
+            return 'TOOL';
+        }
+
+        return 'TOOL';
+    } catch (error) {
+        console.warn('[OpenRouter] Tool intent classification failed:', error);
+        throw error;
+    }
+};
 
 export const getAvailableModels = async (): Promise<ModelInfo[]> => {
     if (!OPEN_ROUTER_API_KEY) {


### PR DESCRIPTION
## Summary
- add a per-model tool intent toggle with persisted state and a pre-flight classifier before Gemini calls
- move model management into the settings dialog while updating the chat pane input behavior and controls
- replace the resizable sidebar with a collapsible panel and refresh the chat list "new chat" affordance

## Testing
- npm run lint *(fails: existing lint rules in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9266aadc8323a49daeb0c64f5a91