### PR TITLE
feat: add tool intent guard and chat layout updates

### DIFF
--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
+import React, { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import ChatSidebar from './ChatSidebar';
 import ChatPane from './ChatPane';
 import { ChatProvider } from '@/hooks/chatProvider';
@@ -7,51 +7,10 @@ import { SystemInstructionsProvider } from '@/hooks/systemInstructionProvider';
 import { ModelSelectionProvider } from '@/hooks/modelSelectionProvider';
 import { McpProvider } from '@/hooks/mcpProvider';
 import { ConversationContextProvider } from '@/hooks/conversationContextProvider';
-import { fetchLayoutBorders, persistLayoutBorders } from '@/services/layoutPersistence';
+import { cn } from '@/lib/utils';
 
 const ChatLayout = () => {
-    const DEFAULT_CHAT_LAYOUT = [20, 80] as const;
-    const [chatLayout, setChatLayout] = useState<number[] | null>(null);
-
-    useEffect(() => {
-        let isMounted = true;
-        const loadLayout = async () => {
-            const borders = await fetchLayoutBorders();
-            const position = borders['chat-horizontal-1']?.position;
-            const layout = typeof position === 'number'
-                ? [position, 100 - position]
-                : [...DEFAULT_CHAT_LAYOUT];
-            if (!borders['chat-horizontal-1']) {
-                void persistLayoutBorders([
-                    { borderId: 'chat-horizontal-1', axis: 'x' as const, position: layout[0] },
-                ]);
-            }
-            if (isMounted) {
-                setChatLayout(layout);
-            }
-        };
-        void loadLayout();
-        return () => {
-            isMounted = false;
-        };
-    }, []);
-
-    const handleChatLayoutChange = useCallback((sizes: number[]) => {
-        setChatLayout(sizes);
-        void persistLayoutBorders([
-            { borderId: 'chat-horizontal-1', axis: 'x' as const, position: sizes[0] },
-        ]);
-    }, []);
-
-    if (!chatLayout) {
-        return (
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-                Loading chat layout...
-            </div>
-        );
-    }
-
-    const resolvedChatLayout = chatLayout;
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
     return (
         <McpProvider>
@@ -59,19 +18,41 @@ const ChatLayout = () => {
                 <SystemInstructionsProvider>
                     <ConversationContextProvider>
                         <ChatProvider>
-                            <ResizablePanelGroup
-                                direction="horizontal"
-                                className="h-full w-full"
-                                onLayout={handleChatLayoutChange}
-                            >
-                                <ResizablePanel defaultSize={resolvedChatLayout[0]} minSize={15} maxSize={30}>
-                                    <ChatSidebar />
-                                </ResizablePanel>
-                                <ResizableHandle withHandle />
-                                <ResizablePanel defaultSize={resolvedChatLayout[1]}>
+                            <div className="flex h-full w-full overflow-hidden bg-background">
+                                <div
+                                    className={cn(
+                                        'relative h-full transition-all duration-300 ease-in-out',
+                                        isSidebarOpen ? 'w-[40%] min-w-[40%]' : 'w-0 min-w-0'
+                                    )}
+                                >
+                                    <div
+                                        className={cn(
+                                            'h-full w-full overflow-hidden border-r bg-card text-card-foreground shadow-sm transition-opacity duration-300',
+                                            isSidebarOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+                                        )}
+                                    >
+                                        <ChatSidebar />
+                                    </div>
+                                </div>
+                                <div className="flex h-full w-8 items-center justify-center">
+                                    <button
+                                        type="button"
+                                        onClick={() => setIsSidebarOpen((prev) => !prev)}
+                                        className="group flex h-24 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground shadow-md transition-colors hover:bg-muted/80"
+                                        aria-expanded={isSidebarOpen}
+                                        aria-label={isSidebarOpen ? 'Collapse chat list' : 'Expand chat list'}
+                                    >
+                                        {isSidebarOpen ? (
+                                            <ChevronLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
+                                        ) : (
+                                            <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                        )}
+                                    </button>
+                                </div>
+                                <div className="flex-1">
                                     <ChatPane />
-                                </ResizablePanel>
-                            </ResizablePanelGroup>
+                                </div>
+                            </div>
                         </ChatProvider>
                     </ConversationContextProvider>
                 </SystemInstructionsProvider>

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -3,15 +3,21 @@ import { useChatContext } from '@/hooks/useChat';
 import { Button } from '../ui/button';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '@/lib/utils';
+import { Plus } from 'lucide-react';
 
 const ChatSidebar = () => {
     const { threads, activeThreadId, setActiveThreadId, createThread } = useChatContext();
 
     return (
         <div className="flex h-full flex-col bg-card p-2 text-card-foreground">
-            <div className="p-2">
-                <Button onClick={createThread} className="w-full justify-center">
-                    <span className="text-sm font-medium">New Chat</span>
+            <div className="flex items-center justify-center p-2">
+                <Button
+                    onClick={createThread}
+                    className="h-10 w-10 rounded-full p-0"
+                    variant="secondary"
+                    title="Start a new chat"
+                >
+                    <Plus className="h-4 w-4" />
                 </Button>
             </div>
             <ScrollArea className="flex-1">

--- a/src/hooks/modelSelectionProviderContext.ts
+++ b/src/hooks/modelSelectionProviderContext.ts
@@ -12,6 +12,8 @@ export interface ModelSelectionContextValue {
     getUsageCount: (modelId: string) => number;
     getUsageScore: (modelId: string) => number;
     usageCounts: Record<string, number>;
+    getToolIntentCheck: (modelId: string) => boolean;
+    setToolIntentCheck: (modelId: string, enabled: boolean) => void;
 }
 
 export const ModelSelectionContext = createContext<ModelSelectionContextValue | undefined>(undefined);


### PR DESCRIPTION
## Summary
- add a tool intent classification helper and wire it into the chat flow so Gemini only receives tools when needed while finishing responses without blocking on title generation
- move model selection into the settings dialog with a dedicated tab, per-model tool intent toggles, and a compact system instruction editor
- update the chat UI with an expanding composer, collapsible sidebar, and an icon-only new chat control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd928493ec8323a1d072460b953b83