### PR TITLE
feat: add preview build notifications

### DIFF
--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -29,6 +29,7 @@ import StatsPanel from './StatsPanel';
 import ChatLayout from './chat/ChatLayout';
 import { useToast } from '@/hooks/use-toast';
 import { fetchLayoutBorders, persistLayoutBorders } from '@/services/layoutPersistence';
+import PreviewBuildsOverlay from './preview-builds/PreviewBuildsOverlay';
 
 const nodeTypes = {
   startNode: StartNode,
@@ -444,7 +445,7 @@ export default function CausalGraph() {
   const resolvedProgressLayout = progressLayoutState ?? [...DEFAULT_PROGRESS_LAYOUT];
 
   return (
-      <div className="w-full h-[100dvh] bg-graph-background">
+      <div className="relative w-full h-[100dvh] bg-graph-background">
         <ResizablePanelGroup
           direction="vertical"
           className="h-full w-full"
@@ -574,6 +575,7 @@ export default function CausalGraph() {
           <ChatLayout />
         </ResizablePanel>
       </ResizablePanelGroup>
+      <PreviewBuildsOverlay />
     </div>
   );
 }

--- a/src/components/preview-builds/PreviewBuildsOverlay.tsx
+++ b/src/components/preview-builds/PreviewBuildsOverlay.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useState } from 'react';
+import { Bell, CheckCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import usePreviewBuilds, { type PreviewBuild } from '@/hooks/usePreviewBuilds';
+import triggerMergeWorkflow from '@/services/githubWorkflows';
+import { useToast } from '@/hooks/use-toast';
+
+const BuildStatusBadge = ({ status }: { status: PreviewBuild['status'] }) => {
+  if (status === 'committed') {
+    return <Badge variant="secondary">Committed</Badge>;
+  }
+  return <Badge variant="outline">Pending review</Badge>;
+};
+
+const PreviewBuildsOverlay = () => {
+  const {
+    builds,
+    loading,
+    error,
+    unseenCount,
+    markAllAsSeen,
+    refresh,
+    setError: setPreviewBuildsError,
+  } = usePreviewBuilds();
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [pendingCommits, setPendingCommits] = useState<number[]>([]);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!panelOpen || unseenCount === 0) {
+      return;
+    }
+
+    const markSeen = async () => {
+      try {
+        await markAllAsSeen();
+      } catch (markError) {
+        toast({
+          title: 'Unable to update build notifications',
+          description:
+            markError instanceof Error ? markError.message : 'Supabase did not accept the update request.',
+          variant: 'destructive',
+        });
+      }
+    };
+
+    void markSeen();
+  }, [panelOpen, unseenCount, markAllAsSeen, toast]);
+
+  useEffect(() => {
+    setPendingCommits((current) =>
+      current.filter((prNumber) => {
+        const build = builds.find((item) => item.pr_number === prNumber);
+        return build ? build.status !== 'committed' : false;
+      })
+    );
+  }, [builds]);
+
+  const handleCommit = async (build: PreviewBuild) => {
+    if (build.status === 'committed' || pendingCommits.includes(build.pr_number)) {
+      return;
+    }
+
+    setPendingCommits((current) => [...current, build.pr_number]);
+
+    try {
+      await triggerMergeWorkflow(build.pr_number);
+      toast({
+        title: `Merge workflow dispatched`,
+        description: `GitHub is merging PR #${build.pr_number}. This panel will update automatically once complete.`,
+      });
+    } catch (commitError) {
+      setPendingCommits((current) => current.filter((value) => value !== build.pr_number));
+      toast({
+        title: 'Failed to trigger merge',
+        description:
+          commitError instanceof Error
+            ? commitError.message
+            : 'An unexpected error occurred while contacting GitHub.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleRetry = async () => {
+    setPreviewBuildsError(null);
+    await refresh();
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Loading preview builds…
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Alert variant="destructive">
+          <AlertTitle>Unable to load preview builds</AlertTitle>
+          <AlertDescription>
+            <div className="space-y-3">
+              <p>{error}</p>
+              <Button variant="outline" size="sm" onClick={handleRetry}>
+                Try again
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
+    if (builds.length === 0) {
+      return (
+        <div className="flex h-32 flex-col items-center justify-center space-y-2 text-center text-sm text-muted-foreground">
+          <CheckCircle className="h-6 w-6 text-muted-foreground" />
+          <p>No preview builds are waiting for review.</p>
+        </div>
+      );
+    }
+
+    return (
+      <ScrollArea className="max-h-[60vh] pr-4">
+        <div className="space-y-3">
+          {builds.map((build) => {
+            const isCommitted = build.status === 'committed';
+            const isCommitting = pendingCommits.includes(build.pr_number) && !isCommitted;
+            const commitLabel = isCommitted ? 'Committed' : isCommitting ? 'Committing…' : 'Commit';
+            const commitDisabled = isCommitted || isCommitting;
+
+            return (
+              <div
+                key={build.pr_number}
+                className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="space-y-1">
+                  <a
+                    href={build.pr_url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-sm font-semibold text-primary hover:underline"
+                  >
+                    PR #{build.pr_number}
+                  </a>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <BuildStatusBadge status={build.status} />
+                    <span>Preview ready</span>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={build.preview_url} target="_blank" rel="noreferrer noopener">
+                      View
+                      <ExternalLink className="ml-1 h-3.5 w-3.5" />
+                    </a>
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={() => handleCommit(build)}
+                    disabled={commitDisabled}
+                    variant={isCommitted ? 'secondary' : 'default'}
+                  >
+                    {commitLabel}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    );
+  };
+
+  return (
+    <>
+      <Dialog open={panelOpen} onOpenChange={setPanelOpen}>
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Preview builds</DialogTitle>
+            <DialogDescription>
+              Review generated preview builds, open their deployments, or trigger a merge when you are satisfied.
+            </DialogDescription>
+          </DialogHeader>
+          {renderContent()}
+        </DialogContent>
+      </Dialog>
+
+      <Button
+        type="button"
+        variant={unseenCount > 0 ? 'default' : 'secondary'}
+        onClick={() => setPanelOpen(true)}
+        className={cn(
+          'fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full shadow-lg transition-transform focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 relative',
+          unseenCount > 0 ? 'build-indicator-animate' : 'hover:scale-105'
+        )}
+        aria-label={
+          unseenCount > 0
+            ? `Open preview builds panel. ${unseenCount} new builds awaiting review.`
+            : 'Open preview builds panel'
+        }
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+        {unseenCount > 0 && (
+          <span className="absolute -top-1 -right-1 flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-destructive px-1 text-xs font-semibold text-destructive-foreground">
+            {unseenCount > 99 ? '99+' : unseenCount}
+          </span>
+        )}
+        <span className="sr-only">
+          {unseenCount > 0
+            ? `${unseenCount} preview builds waiting for review`
+            : 'No new preview builds'}
+        </span>
+      </Button>
+    </>
+  );
+};
+
+export default PreviewBuildsOverlay;

--- a/src/custom-styles.css
+++ b/src/custom-styles.css
@@ -12,3 +12,19 @@ The SVG scales, so we need a larger base font size to ensure readability.
 .progress-graph-svg text {
     font-size: 28px !important;
 }
+
+@keyframes build-indicator-pulse {
+    0%,
+    100% {
+        transform: scale(1);
+        box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.45);
+    }
+    50% {
+        transform: scale(1.08);
+        box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
+    }
+}
+
+.build-indicator-animate {
+    animation: build-indicator-pulse 1.8s ease-in-out infinite;
+}

--- a/src/hooks/usePreviewBuilds.ts
+++ b/src/hooks/usePreviewBuilds.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+export type PreviewBuild = Database['public']['Tables']['preview_builds']['Row'];
+
+const sortBuilds = (builds: PreviewBuild[]) =>
+  [...builds].sort((a, b) => {
+    const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+    if (aTime !== bTime) {
+      return bTime - aTime;
+    }
+    return b.pr_number - a.pr_number;
+  });
+
+export const usePreviewBuilds = () => {
+  const [builds, setBuilds] = useState<PreviewBuild[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBuilds = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: fetchError } = await supabase
+      .from('preview_builds')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (fetchError) {
+      setError(fetchError.message);
+      setLoading(false);
+      return;
+    }
+
+    setBuilds(data ? sortBuilds(data as PreviewBuild[]) : []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void fetchBuilds();
+  }, [fetchBuilds]);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('preview_builds_changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'preview_builds' }, (payload) => {
+        if (payload.eventType === 'INSERT' || payload.eventType === 'UPDATE') {
+          const next = payload.new as PreviewBuild | null;
+          if (!next) return;
+          setBuilds((previous) => sortBuilds([next, ...previous.filter((item) => item.pr_number !== next.pr_number)]));
+          setError(null);
+        }
+
+        if (payload.eventType === 'DELETE') {
+          const previous = payload.old as Partial<PreviewBuild> | null;
+          if (!previous?.pr_number) return;
+          setBuilds((existing) => existing.filter((item) => item.pr_number !== previous.pr_number));
+        }
+      })
+      .subscribe((status) => {
+        if (status === 'CHANNEL_ERROR') {
+          setError('Real-time subscription to preview builds failed. Updates may be delayed.');
+        }
+      });
+
+    return () => {
+      try {
+        supabase.removeChannel(channel);
+      } catch (subscriptionError) {
+        console.error('Failed to remove preview_builds realtime channel', subscriptionError);
+      }
+    };
+  }, []);
+
+  const unseenCount = useMemo(() => builds.filter((build) => !build.is_seen).length, [builds]);
+
+  const markAllAsSeen = useCallback(async () => {
+    let hadChanges = false;
+    setBuilds((previous) => {
+      const next = previous.map((build) => {
+        if (!build.is_seen) {
+          hadChanges = true;
+          return { ...build, is_seen: true };
+        }
+        return build;
+      });
+      return next;
+    });
+
+    if (!hadChanges) {
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from('preview_builds')
+      .update({ is_seen: true })
+      .eq('is_seen', false);
+
+    if (updateError) {
+      setError(updateError.message);
+      await fetchBuilds();
+      throw updateError;
+    }
+  }, [fetchBuilds]);
+
+  const refresh = useCallback(async () => {
+    await fetchBuilds();
+  }, [fetchBuilds]);
+
+  return {
+    builds,
+    loading,
+    error,
+    unseenCount,
+    markAllAsSeen,
+    refresh,
+    setError,
+  };
+};
+
+export default usePreviewBuilds;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -181,6 +181,36 @@ export type Database = {
           },
         ]
       }
+      preview_builds: {
+        Row: {
+          created_at: string | null
+          id: string
+          is_seen: boolean
+          preview_url: string
+          pr_number: number
+          pr_url: string
+          status: "pending_review" | "committed"
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          is_seen?: boolean
+          preview_url: string
+          pr_number: number
+          pr_url: string
+          status?: "pending_review" | "committed"
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          is_seen?: boolean
+          preview_url?: string
+          pr_number?: number
+          pr_url?: string
+          status?: "pending_review" | "committed"
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/services/githubWorkflows.ts
+++ b/src/services/githubWorkflows.ts
@@ -1,0 +1,47 @@
+const GITHUB_WORKFLOW_TOKEN = import.meta.env.VITE_GITHUB_WORKFLOW_TOKEN;
+const GITHUB_REPOSITORY_OWNER = import.meta.env.VITE_GITHUB_OWNER;
+const GITHUB_REPOSITORY_NAME = import.meta.env.VITE_GITHUB_REPO;
+const GITHUB_MERGE_WORKFLOW_ID = import.meta.env.VITE_GITHUB_MERGE_WORKFLOW ?? 'merge_pr.yml';
+const GITHUB_DEFAULT_BRANCH = import.meta.env.VITE_GITHUB_DEFAULT_BRANCH ?? 'main';
+
+const buildMissingEnvError = (variable: string) =>
+  new Error(`${variable} is not defined. Please add it to your Vite environment configuration.`);
+
+export const triggerMergeWorkflow = async (prNumber: number): Promise<void> => {
+  if (!GITHUB_WORKFLOW_TOKEN) {
+    throw buildMissingEnvError('VITE_GITHUB_WORKFLOW_TOKEN');
+  }
+  if (!GITHUB_REPOSITORY_OWNER) {
+    throw buildMissingEnvError('VITE_GITHUB_OWNER');
+  }
+  if (!GITHUB_REPOSITORY_NAME) {
+    throw buildMissingEnvError('VITE_GITHUB_REPO');
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPOSITORY_OWNER}/${GITHUB_REPOSITORY_NAME}/actions/workflows/${GITHUB_MERGE_WORKFLOW_ID}/dispatches`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_WORKFLOW_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ref: GITHUB_DEFAULT_BRANCH,
+        inputs: {
+          pr_number: String(prNumber),
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to dispatch merge workflow for PR #${prNumber}: ${response.status} ${response.statusText} - ${errorText}`
+    );
+  }
+};
+
+export default triggerMergeWorkflow;


### PR DESCRIPTION
## Summary
- add a floating preview build indicator and review dialog wired to Supabase real-time updates
- provide actions to view previews, mark them as seen, and trigger the GitHub merge workflow with optimistic UI states
- define the preview_builds table types, supporting hook, GitHub workflow helper, and notification animation styles

## Testing
- npm run lint *(fails: existing lint warnings/error in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e007e704ec8323ad2fd6a116bd2f0c