### PR TITLE
Codex Build (Instance 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,8 +2,13 @@ import CausalGraph from "@/components/CausalGraph";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
-      <CausalGraph />
+    <div className="h-[100svh] w-full overflow-hidden flex">
+      <div className="flex items-center justify-center bg-black/40 px-6 text-lg font-semibold text-yellow-300">
+        Inserted to test
+      </div>
+      <div className="flex-1">
+        <CausalGraph />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Automated Codex run output:

Added a fixed left-side panel with bold yellow copy so “Inserted to test” always shows against the graph layout (`src/pages/Index.tsx:6`). The remaining area keeps rendering `CausalGraph` as before.  

Next step: 1. Run `npm run dev` and confirm the banner looks right in the browser.