### PR TITLE
Codex Build (Instance 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,10 @@ import CausalGraph from "@/components/CausalGraph";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
+    <div className="relative h-[100svh] w-full overflow-hidden">
+      <div className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-yellow-400 drop-shadow-md">
+        Inserted to test
+      </div>
       <CausalGraph />
     </div>
   );


### PR DESCRIPTION
Automated Codex run output:

- Added a left-anchored overlay inside the main page container so the yellow “Inserted to test” label stays visible without blocking interactions (`src/pages/Index.tsx:5`).

Next steps:
1. Run `npm run dev` and confirm the label appears where you expect.