### PR TITLE
Codex Build (Instance 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -454,6 +454,9 @@ export default function CausalGraph() {
           <ResizablePanelGroup direction="horizontal" onLayout={handleTopLayoutChange} className="h-full">
             {/* Left: Main graph */}
             <ResizablePanel defaultSize={resolvedTopLayout[0]} minSize={40} className="relative">
+              <div className="absolute left-4 top-4 z-50 text-yellow-400 text-lg font-semibold drop-shadow bg-black/70 px-3 py-1 rounded">
+                Inserted to test
+              </div>
               <ReactFlow
                 nodes={nodesWithActions}
                 edges={edges}


### PR DESCRIPTION
Automated Codex run output:

**Change**
- Added an absolute-positioned, yellow-on-dark label in the left graph panel so “Inserted to test” appears on the left side (`src/components/CausalGraph.tsx:457`).

**Status**
- Tests not run (visual-only tweak).

Next: 1. `npm run dev` to confirm the text renders where expected.