### PR TITLE
Codex Build (Instance 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -444,13 +444,16 @@ export default function CausalGraph() {
   const resolvedProgressLayout = progressLayoutState ?? [...DEFAULT_PROGRESS_LAYOUT];
 
   return (
-      <div className="w-full h-[100dvh] bg-graph-background">
-        <ResizablePanelGroup
-          direction="vertical"
-          className="h-full w-full"
-          onLayout={handleMainVerticalLayoutChange}
-        >
-          <ResizablePanel defaultSize={resolvedMainVerticalLayout[0]}>
+    <div className="relative w-full h-[100dvh] bg-graph-background">
+      <div className="absolute left-4 top-4 z-50 rounded bg-black/60 px-3 py-1 text-lg font-semibold text-yellow-400">
+        Inserted to test
+      </div>
+      <ResizablePanelGroup
+        direction="vertical"
+        className="h-full w-full"
+        onLayout={handleMainVerticalLayoutChange}
+      >
+        <ResizablePanel defaultSize={resolvedMainVerticalLayout[0]}>
           <ResizablePanelGroup direction="horizontal" onLayout={handleTopLayoutChange} className="h-full">
             {/* Left: Main graph */}
             <ResizablePanel defaultSize={resolvedTopLayout[0]} minSize={40} className="relative">


### PR DESCRIPTION
Automated Codex run output:

Added an always-visible yellow label on the left by making the root graph wrapper `relative` and overlaying a styled callout with “Inserted to test”. See `src/components/CausalGraph.tsx:447-449`. No tests run.