### PR TITLE
Codex Build (Instance 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,8 +2,13 @@ import CausalGraph from "@/components/CausalGraph";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
-      <CausalGraph />
+    <div className="flex h-[100svh] w-full overflow-hidden">
+      <div className="flex w-60 items-center justify-center bg-black">
+        <span className="text-xl font-semibold text-yellow-300">Inserted to test</span>
+      </div>
+      <div className="h-full flex-1">
+        <CausalGraph />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Automated Codex run output:

- Added a fixed-width left column with a black background and yellow text reading “Inserted to test” so it stays visible beside the main graph (`src/pages/Index.tsx:5`).
- Kept the graph filling the remaining viewport area by wrapping it in a flex container (`src/pages/Index.tsx:9`).

Next step: 1. Start the dev server (`npm run dev`) to confirm the new layout looks correct in the browser.