### PR TITLE
Codex Build (Instance 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -444,7 +444,10 @@ export default function CausalGraph() {
   const resolvedProgressLayout = progressLayoutState ?? [...DEFAULT_PROGRESS_LAYOUT];
 
   return (
-      <div className="w-full h-[100dvh] bg-graph-background">
+      <div className="relative w-full h-[100dvh] bg-graph-background">
+        <div className="absolute left-4 top-1/2 -translate-y-1/2 text-yellow-400 text-3xl font-bold drop-shadow-lg pointer-events-none">
+          Inserted to test
+        </div>
         <ResizablePanelGroup
           direction="vertical"
           className="h-full w-full"


### PR DESCRIPTION
Automated Codex run output:

- Added a left-side overlay with yellow “Inserted to test” text and made the root container relative so the label stays fixed (`src/components/CausalGraph.tsx:447`).

Next: 1) Run `npm run dev` and load the app to verify the placement. 2) Adjust styling if you need different positioning or emphasis.