### PR TITLE
Codex Build (Instance 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,9 @@ import CausalGraph from "@/components/CausalGraph";
 const Index = () => {
   return (
     <div className="h-[100svh] w-full overflow-hidden">
+      <div className="fixed inset-y-0 left-0 z-50 flex items-center pl-4">
+        <span className="text-yellow-300 text-2xl font-semibold drop-shadow">Inserted to test</span>
+      </div>
       <CausalGraph />
     </div>
   );


### PR DESCRIPTION
Automated Codex run output:

Added a fixed left-side overlay so the yellow “Inserted to test” label stays visible on the screen (`src/pages/Index.tsx:5-9`).  
Consider running `npm run dev` to confirm the placement and appearance look right in the browser.