### PR TITLE
Codex Build (Instance 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <div className="fixed left-4 top-1/2 z-50 -translate-y-1/2 rounded bg-black/80 px-3 py-2 text-lg font-semibold text-yellow-300">
+        Inserted to test
+      </div>
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />


### PR DESCRIPTION
Automated Codex run output:

Added a fixed yellow label on the left edge so the message stays visible across the app.
- `src/App.tsx:16`: insert a `div` with high z-index, dark backdrop, and yellow text saying “Inserted to test”.

Tests not run (UI change only). Next up: 1. `npm run dev` to confirm the overlay looks right in the browser.