### PR TITLE
Codex Build (Instance 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,10 @@ import CausalGraph from "@/components/CausalGraph";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
+    <div className="relative h-[100svh] w-full overflow-hidden">
+      <div className="absolute left-0 top-1/2 z-50 -translate-y-1/2 bg-black/60 px-4 py-2 text-2xl font-semibold text-yellow-300">
+        Inserted to test
+      </div>
       <CausalGraph />
     </div>
   );


### PR DESCRIPTION
Automated Codex run output:

Added a fixed left-side banner with yellow text by making the page container `relative` and overlaying the message (`src/pages/Index.tsx:6`). The banner sits mid-screen with a translucent backdrop so “Inserted to test” stays readable over the app content.

You can run `npm run dev` to verify the positioning in the browser.