### PR TITLE
Codex Build (Instance 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/CausalGraph.tsx
+++ b/src/components/CausalGraph.tsx
@@ -454,6 +454,9 @@ export default function CausalGraph() {
           <ResizablePanelGroup direction="horizontal" onLayout={handleTopLayoutChange} className="h-full">
             {/* Left: Main graph */}
             <ResizablePanel defaultSize={resolvedTopLayout[0]} minSize={40} className="relative">
+              <div className="absolute left-4 top-1/2 -translate-y-1/2 z-50 bg-black/70 px-3 py-2 text-yellow-300 text-xl font-semibold rounded">
+                Inserted to test
+              </div>
               <ReactFlow
                 nodes={nodesWithActions}
                 edges={edges}


### PR DESCRIPTION
Automated Codex run output:

Added an absolute-positioned overlay inside the left ResizablePanel so `Inserted to test` appears in bright yellow along the left edge for the main graph view.  

- `src/components/CausalGraph.tsx:456` adds the styled overlay div with yellow text anchored to the left side.

Tests not run (not requested).

Next steps:
1. Run `npm run dev` and load the main view to confirm the text placement matches expectations.