### PR TITLE
Codex Build (Instance 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,8 +2,15 @@ import CausalGraph from "@/components/CausalGraph";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
-      <CausalGraph />
+    <div className="flex h-[100svh] w-full overflow-hidden">
+      <div className="flex w-64 shrink-0 items-center justify-center bg-black/80 px-4">
+        <span className="text-2xl font-semibold text-yellow-400">
+          Inserted to test
+        </span>
+      </div>
+      <div className="flex-1">
+        <CausalGraph />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Automated Codex run output:

Added a fixed left column with prominent yellow text so the message stays visible while the main graph renders alongside.  
- `src/pages/Index.tsx:5` switches the container to a flex layout so the new column and `CausalGraph` share the viewport.  
- `src/pages/Index.tsx:6-9` renders the “Inserted to test” message in bold yellow on a dark backdrop for contrast.

No tests run – not applicable.

Next step: 1. Run `npm run dev` to visually confirm the placement.