### PR TITLE
Codex Build (Instance 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,9 @@ import CausalGraph from "@/components/CausalGraph";
 const Index = () => {
   return (
     <div className="h-[100svh] w-full overflow-hidden">
+      <div className="fixed left-4 top-1/2 -translate-y-1/2 text-yellow-400 text-3xl font-bold drop-shadow pointer-events-none z-[9999]">
+        Inserted to test
+      </div>
       <CausalGraph />
     </div>
   );


### PR DESCRIPTION
Automated Codex run output:

Added a fixed-position overlay with bold yellow text so “Inserted to test” stays visible along the left edge of the viewport (`src/pages/Index.tsx:6`). Next step: run `npm run dev` and open the app to confirm the banner renders as expected.