### PR TITLE
Codex Build (Instance 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.83.0",
         "@xyflow/react": "^12.8.4",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.83.0",
     "@xyflow/react": "^12.8.4",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,7 +3,10 @@ import PreviewBuildsWidget from "@/components/builds/PreviewBuildsWidget";
 
 const Index = () => {
   return (
-    <div className="h-[100svh] w-full overflow-hidden">
+    <div className="relative h-[100svh] w-full overflow-hidden">
+      <div className="pointer-events-none absolute left-6 top-1/2 -translate-y-1/2 text-4xl font-extrabold uppercase text-yellow-300 drop-shadow-lg">
+        Inserted to test
+      </div>
       <CausalGraph />
       <PreviewBuildsWidget />
     </div>


### PR DESCRIPTION
Automated Codex run output:

Added a left-side overlay in `src/pages/Index.tsx:6` using an absolutely positioned container so the message “Inserted to test” appears in bold yellow with a drop shadow, keeping existing interactions unaffected via `pointer-events-none`.

Next step: 1) Run `npm run dev` and confirm the text placement and contrast look right in the browser.